### PR TITLE
Discovery Plugin Changes for Scala 2.13 (and Google Drive)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -71,6 +71,24 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
   .jvmSettings(commonJVMSettings)
   .jsSettings(commonJSSettings)
 
+// ideally this would dependOn(core), but I can't find a way to do it with CrossVersion.for3Use2_13
+val `drive-client` = crossProject(JVMPlatform, JSPlatform)
+  .in(file("google-drive"))
+  .enablePlugins(DiscoveryPlugin)
+  .settings(
+    name := "gcp4s-drive",
+    discoveryPackage := "gcp4s.drive",
+    crossScalaVersions := Seq("2.13.8"),
+    scalacOptions := List("-encoding", "utf8", "-feature", "-unchecked", "-language:existentials", "-language:experimental.macros", "-language:higherKinds", "-language:implicitConversions", "-Xcheckinit", "-Xlint:adapted-args", "-Xlint:constant", "-Xlint:delayedinit-select", "-Xlint:deprecation", "-Xlint:doc-detached", "-Xlint:implicit-recursion", "-Xlint:implicit-not-found", "-Xlint:inaccessible", "-Xlint:infer-any", "-Xlint:missing-interpolator", "-Xlint:nullary-unit", "-Xlint:option-implicit", "-Xlint:package-object-classes", "-Xlint:poly-implicit-overload", "-Xlint:private-shadow", "-Xlint:stars-align", "-Xlint:strict-unsealed-patmat", "-Xlint:type-parameter-shadow", "-Xlint:-byname-implicit", "-Wdead-code", "-Wextra-implicit", "-Wnumeric-widen", "-Wvalue-discard", "-Wunused:nowarn", "-Wunused:implicits", "-Wunused:explicits", "-Wunused:locals", "-Wunused:params", "-Wunused:patvars", "-Wunused:privates", "-Xfatal-warnings"),
+    libraryDependencies ++= {
+      Seq(
+        "io.circe" %% "circe-generic" % "0.14.2" cross CrossVersion.for3Use2_13,
+        "io.circe" %% "circe-scodec" % "0.14.2" cross CrossVersion.for3Use2_13,
+        "org.scodec" %% "scodec-bits" % "1.1.34" cross CrossVersion.for3Use2_13,
+      )
+    }
+  )
+
 // lazy val bigQuery = crossProject(JVMPlatform, JSPlatform)
 //   .crossType(CrossType.Pure)
 //   .in(file("bigquery"))

--- a/google-drive/shared/src/main/discovery/drive.json
+++ b/google-drive/shared/src/main/discovery/drive.json
@@ -1,0 +1,6086 @@
+{
+  "kind": "discovery#restDescription",
+  "etag": "\"uWj2hSb4GVjzdDlAnRd2gbM1ZQ8/sMwXONEBRkKQmysXXZDWtmF2KK4\"",
+  "discoveryVersion": "v1",
+  "id": "drive:v2",
+  "name": "drive",
+  "version": "v2",
+  "revision": "20220606",
+  "title": "Drive API",
+  "description": "Manages files in Drive including uploading, downloading, searching, detecting changes, and updating sharing permissions.",
+  "ownerDomain": "google.com",
+  "ownerName": "Google",
+  "icons": {
+    "x16": "https://ssl.gstatic.com/docs/doclist/images/drive_icon_16.png",
+    "x32": "https://ssl.gstatic.com/docs/doclist/images/drive_icon_32.png"
+  },
+  "documentationLink": "https://developers.google.com/drive/",
+  "protocol": "rest",
+  "baseUrl": "https://www.googleapis.com/drive/v2/",
+  "basePath": "/drive/v2/",
+  "rootUrl": "https://www.googleapis.com/",
+  "servicePath": "drive/v2/",
+  "batchPath": "batch/drive/v2",
+  "parameters": {
+    "alt": {
+      "type": "string",
+      "description": "Data format for the response.",
+      "default": "json",
+      "enum": [
+        "json"
+      ],
+      "enumDescriptions": [
+        "Responses with Content-Type of application/json"
+      ],
+      "location": "query"
+    },
+    "fields": {
+      "type": "string",
+      "description": "Selector specifying which fields to include in a partial response.",
+      "location": "query"
+    },
+    "key": {
+      "type": "string",
+      "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
+      "location": "query"
+    },
+    "oauth_token": {
+      "type": "string",
+      "description": "OAuth 2.0 token for the current user.",
+      "location": "query"
+    },
+    "prettyPrint": {
+      "type": "boolean",
+      "description": "Returns response with indentations and line breaks.",
+      "default": "true",
+      "location": "query"
+    },
+    "quotaUser": {
+      "type": "string",
+      "description": "An opaque string that represents a user for quota purposes. Must not exceed 40 characters.",
+      "location": "query"
+    },
+    "userIp": {
+      "type": "string",
+      "description": "Deprecated. Please use quotaUser instead.",
+      "location": "query"
+    }
+  },
+  "auth": {
+    "oauth2": {
+      "scopes": {
+        "https://www.googleapis.com/auth/drive": {
+          "description": "See, edit, create, and delete all of your Google Drive files"
+        },
+        "https://www.googleapis.com/auth/drive.appdata": {
+          "description": "See, create, and delete its own configuration data in your Google Drive"
+        },
+        "https://www.googleapis.com/auth/drive.apps.readonly": {
+          "description": "View your Google Drive apps"
+        },
+        "https://www.googleapis.com/auth/drive.file": {
+          "description": "See, edit, create, and delete only the specific Google Drive files you use with this app"
+        },
+        "https://www.googleapis.com/auth/drive.metadata": {
+          "description": "View and manage metadata of files in your Google Drive"
+        },
+        "https://www.googleapis.com/auth/drive.metadata.readonly": {
+          "description": "See information about your Google Drive files"
+        },
+        "https://www.googleapis.com/auth/drive.photos.readonly": {
+          "description": "View the photos, videos and albums in your Google Photos"
+        },
+        "https://www.googleapis.com/auth/drive.readonly": {
+          "description": "See and download all your Google Drive files"
+        },
+        "https://www.googleapis.com/auth/drive.scripts": {
+          "description": "Modify your Google Apps Script scripts' behavior"
+        }
+      }
+    }
+  },
+  "schemas": {
+    "About": {
+      "id": "About",
+      "type": "object",
+      "description": "An item with user information and settings.",
+      "properties": {
+        "additionalRoleInfo": {
+          "type": "array",
+          "description": "Information about supported additional roles per file type. The most specific type takes precedence.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "roleSets": {
+                "type": "array",
+                "description": "The supported additional roles per primary role.",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "additionalRoles": {
+                      "type": "array",
+                      "description": "The supported additional roles with the primary role.",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "primaryRole": {
+                      "type": "string",
+                      "description": "A primary permission role."
+                    }
+                  }
+                }
+              },
+              "type": {
+                "type": "string",
+                "description": "The content type that this additional role info applies to."
+              }
+            }
+          }
+        },
+        "canCreateDrives": {
+          "type": "boolean",
+          "description": "Whether the user can create shared drives."
+        },
+        "canCreateTeamDrives": {
+          "type": "boolean",
+          "description": "Deprecated - use canCreateDrives instead."
+        },
+        "domainSharingPolicy": {
+          "type": "string",
+          "description": "The domain sharing policy for the current user. Possible values are:  \n- allowed \n- allowedWithWarning \n- incomingOnly \n- disallowed"
+        },
+        "driveThemes": {
+          "type": "array",
+          "description": "A list of themes that are supported for shared drives.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "backgroundImageLink": {
+                "type": "string",
+                "description": "A link to this theme's background image."
+              },
+              "colorRgb": {
+                "type": "string",
+                "description": "The color of this theme as an RGB hex string."
+              },
+              "id": {
+                "type": "string",
+                "description": "The ID of the theme."
+              }
+            }
+          }
+        },
+        "etag": {
+          "type": "string",
+          "description": "The ETag of the item."
+        },
+        "exportFormats": {
+          "type": "array",
+          "description": "The allowable export formats.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "source": {
+                "type": "string",
+                "description": "The content type to convert from."
+              },
+              "targets": {
+                "type": "array",
+                "description": "The possible content types to convert to.",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "features": {
+          "type": "array",
+          "description": "List of additional features enabled on this account.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "featureName": {
+                "type": "string",
+                "description": "The name of the feature."
+              },
+              "featureRate": {
+                "type": "number",
+                "description": "The request limit rate for this feature, in queries per second.",
+                "format": "double"
+              }
+            }
+          }
+        },
+        "folderColorPalette": {
+          "type": "array",
+          "description": "The palette of allowable folder colors as RGB hex strings.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "importFormats": {
+          "type": "array",
+          "description": "The allowable import formats.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "source": {
+                "type": "string",
+                "description": "The imported file's content type to convert from."
+              },
+              "targets": {
+                "type": "array",
+                "description": "The possible content types to convert to.",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "isCurrentAppInstalled": {
+          "type": "boolean",
+          "description": "A boolean indicating whether the authenticated app is installed by the authenticated user."
+        },
+        "kind": {
+          "type": "string",
+          "description": "This is always drive#about.",
+          "default": "drive#about"
+        },
+        "languageCode": {
+          "type": "string",
+          "description": "The user's language or locale code, as defined by BCP 47, with some extensions from Unicode's LDML format (http://www.unicode.org/reports/tr35/)."
+        },
+        "largestChangeId": {
+          "type": "string",
+          "description": "The largest change id.",
+          "format": "int64"
+        },
+        "maxUploadSizes": {
+          "type": "array",
+          "description": "List of max upload sizes for each file type. The most specific type takes precedence.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "size": {
+                "type": "string",
+                "description": "The max upload size for this type.",
+                "format": "int64"
+              },
+              "type": {
+                "type": "string",
+                "description": "The file type."
+              }
+            }
+          }
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the current user."
+        },
+        "permissionId": {
+          "type": "string",
+          "description": "The current user's ID as visible in the permissions collection."
+        },
+        "quotaBytesByService": {
+          "type": "array",
+          "description": "The amount of storage quota used by different Google services.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "bytesUsed": {
+                "type": "string",
+                "description": "The storage quota bytes used by the service.",
+                "format": "int64"
+              },
+              "serviceName": {
+                "type": "string",
+                "description": "The service's name, e.g. DRIVE, GMAIL, or PHOTOS."
+              }
+            }
+          }
+        },
+        "quotaBytesTotal": {
+          "type": "string",
+          "description": "The total number of quota bytes. This is only relevant when quotaType is LIMITED.",
+          "format": "int64"
+        },
+        "quotaBytesUsed": {
+          "type": "string",
+          "description": "The number of quota bytes used by Google Drive.",
+          "format": "int64"
+        },
+        "quotaBytesUsedAggregate": {
+          "type": "string",
+          "description": "The number of quota bytes used by all Google apps (Drive, Picasa, etc.).",
+          "format": "int64"
+        },
+        "quotaBytesUsedInTrash": {
+          "type": "string",
+          "description": "The number of quota bytes used by trashed items.",
+          "format": "int64"
+        },
+        "quotaType": {
+          "type": "string",
+          "description": "The type of the user's storage quota. Possible values are:  \n- LIMITED \n- UNLIMITED"
+        },
+        "remainingChangeIds": {
+          "type": "string",
+          "description": "The number of remaining change ids, limited to no more than 2500.",
+          "format": "int64"
+        },
+        "rootFolderId": {
+          "type": "string",
+          "description": "The id of the root folder."
+        },
+        "selfLink": {
+          "type": "string",
+          "description": "A link back to this item."
+        },
+        "teamDriveThemes": {
+          "type": "array",
+          "description": "Deprecated - use driveThemes instead.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "backgroundImageLink": {
+                "type": "string",
+                "description": "Deprecated - use driveThemes/backgroundImageLink instead."
+              },
+              "colorRgb": {
+                "type": "string",
+                "description": "Deprecated - use driveThemes/colorRgb instead."
+              },
+              "id": {
+                "type": "string",
+                "description": "Deprecated - use driveThemes/id instead."
+              }
+            }
+          }
+        },
+        "user": {
+          "$ref": "User",
+          "description": "The authenticated user."
+        }
+      }
+    },
+    "App": {
+      "id": "App",
+      "type": "object",
+      "description": "The apps resource provides a list of the apps that a user has installed, with information about each app's supported MIME types, file extensions, and other details.",
+      "properties": {
+        "authorized": {
+          "type": "boolean",
+          "description": "Whether the app is authorized to access data on the user's Drive."
+        },
+        "createInFolderTemplate": {
+          "type": "string",
+          "description": "The template url to create a new file with this app in a given folder. The template will contain {folderId} to be replaced by the folder to create the new file in."
+        },
+        "createUrl": {
+          "type": "string",
+          "description": "The url to create a new file with this app."
+        },
+        "hasDriveWideScope": {
+          "type": "boolean",
+          "description": "Whether the app has drive-wide scope. An app with drive-wide scope can access all files in the user's drive."
+        },
+        "icons": {
+          "type": "array",
+          "description": "The various icons for the app.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "category": {
+                "type": "string",
+                "description": "Category of the icon. Allowed values are:  \n- application - icon for the application \n- document - icon for a file associated with the app \n- documentShared - icon for a shared file associated with the app"
+              },
+              "iconUrl": {
+                "type": "string",
+                "description": "URL for the icon."
+              },
+              "size": {
+                "type": "integer",
+                "description": "Size of the icon. Represented as the maximum of the width and height.",
+                "format": "int32"
+              }
+            }
+          }
+        },
+        "id": {
+          "type": "string",
+          "description": "The ID of the app."
+        },
+        "installed": {
+          "type": "boolean",
+          "description": "Whether the app is installed."
+        },
+        "kind": {
+          "type": "string",
+          "description": "This is always drive#app.",
+          "default": "drive#app"
+        },
+        "longDescription": {
+          "type": "string",
+          "description": "A long description of the app."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the app."
+        },
+        "objectType": {
+          "type": "string",
+          "description": "The type of object this app creates (e.g. Chart). If empty, the app name should be used instead."
+        },
+        "openUrlTemplate": {
+          "type": "string",
+          "description": "The template url for opening files with this app. The template will contain {ids} and/or {exportIds} to be replaced by the actual file ids. See  Open Files  for the full documentation."
+        },
+        "primaryFileExtensions": {
+          "type": "array",
+          "description": "The list of primary file extensions.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primaryMimeTypes": {
+          "type": "array",
+          "description": "The list of primary mime types.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "productId": {
+          "type": "string",
+          "description": "The ID of the product listing for this app."
+        },
+        "productUrl": {
+          "type": "string",
+          "description": "A link to the product listing for this app."
+        },
+        "secondaryFileExtensions": {
+          "type": "array",
+          "description": "The list of secondary file extensions.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "secondaryMimeTypes": {
+          "type": "array",
+          "description": "The list of secondary mime types.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "shortDescription": {
+          "type": "string",
+          "description": "A short description of the app."
+        },
+        "supportsCreate": {
+          "type": "boolean",
+          "description": "Whether this app supports creating new objects."
+        },
+        "supportsImport": {
+          "type": "boolean",
+          "description": "Whether this app supports importing from Docs Editors."
+        },
+        "supportsMultiOpen": {
+          "type": "boolean",
+          "description": "Whether this app supports opening more than one file."
+        },
+        "supportsOfflineCreate": {
+          "type": "boolean",
+          "description": "Whether this app supports creating new files when offline."
+        },
+        "useByDefault": {
+          "type": "boolean",
+          "description": "Whether the app is selected as the default handler for the types it supports."
+        }
+      }
+    },
+    "AppList": {
+      "id": "AppList",
+      "type": "object",
+      "description": "A list of third-party applications which the user has installed or given access to Google Drive.",
+      "properties": {
+        "defaultAppIds": {
+          "type": "array",
+          "description": "List of app IDs that the user has specified to use by default. The list is in reverse-priority order (lowest to highest).",
+          "items": {
+            "type": "string"
+          }
+        },
+        "etag": {
+          "type": "string",
+          "description": "The ETag of the list."
+        },
+        "items": {
+          "type": "array",
+          "description": "The list of apps.",
+          "items": {
+            "$ref": "App"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "This is always drive#appList.",
+          "default": "drive#appList"
+        },
+        "selfLink": {
+          "type": "string",
+          "description": "A link back to this list."
+        }
+      }
+    },
+    "Change": {
+      "id": "Change",
+      "type": "object",
+      "description": "Representation of a change to a file or shared drive.",
+      "properties": {
+        "changeType": {
+          "type": "string",
+          "description": "The type of the change. Possible values are file and drive."
+        },
+        "deleted": {
+          "type": "boolean",
+          "description": "Whether the file or shared drive has been removed from this list of changes, for example by deletion or loss of access."
+        },
+        "drive": {
+          "$ref": "Drive",
+          "description": "The updated state of the shared drive. Present if the changeType is drive, the user is still a member of the shared drive, and the shared drive has not been deleted."
+        },
+        "driveId": {
+          "type": "string",
+          "description": "The ID of the shared drive associated with this change."
+        },
+        "file": {
+          "$ref": "File",
+          "description": "The updated state of the file. Present if the type is file and the file has not been removed from this list of changes."
+        },
+        "fileId": {
+          "type": "string",
+          "description": "The ID of the file associated with this change."
+        },
+        "id": {
+          "type": "string",
+          "description": "The ID of the change.",
+          "format": "int64"
+        },
+        "kind": {
+          "type": "string",
+          "description": "This is always drive#change.",
+          "default": "drive#change"
+        },
+        "modificationDate": {
+          "type": "string",
+          "description": "The time of this modification.",
+          "format": "date-time"
+        },
+        "selfLink": {
+          "type": "string",
+          "description": "A link back to this change."
+        },
+        "teamDrive": {
+          "$ref": "TeamDrive",
+          "description": "Deprecated - use drive instead."
+        },
+        "teamDriveId": {
+          "type": "string",
+          "description": "Deprecated - use driveId instead."
+        },
+        "type": {
+          "type": "string",
+          "description": "Deprecated - use changeType instead."
+        }
+      }
+    },
+    "ChangeList": {
+      "id": "ChangeList",
+      "type": "object",
+      "description": "A list of changes for a user.",
+      "properties": {
+        "etag": {
+          "type": "string",
+          "description": "The ETag of the list."
+        },
+        "items": {
+          "type": "array",
+          "description": "The list of changes. If nextPageToken is populated, then this list may be incomplete and an additional page of results should be fetched.",
+          "items": {
+            "$ref": "Change"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "This is always drive#changeList.",
+          "default": "drive#changeList"
+        },
+        "largestChangeId": {
+          "type": "string",
+          "description": "The current largest change ID.",
+          "format": "int64"
+        },
+        "newStartPageToken": {
+          "type": "string",
+          "description": "The starting page token for future changes. This will be present only if the end of the current changes list has been reached."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "A link to the next page of changes."
+        },
+        "nextPageToken": {
+          "type": "string",
+          "description": "The page token for the next page of changes. This will be absent if the end of the changes list has been reached. If the token is rejected for any reason, it should be discarded, and pagination should be restarted from the first page of results."
+        },
+        "selfLink": {
+          "type": "string",
+          "description": "A link back to this list."
+        }
+      }
+    },
+    "Channel": {
+      "id": "Channel",
+      "type": "object",
+      "description": "An notification channel used to watch for resource changes.",
+      "properties": {
+        "address": {
+          "type": "string",
+          "description": "The address where notifications are delivered for this channel."
+        },
+        "expiration": {
+          "type": "string",
+          "description": "Date and time of notification channel expiration, expressed as a Unix timestamp, in milliseconds. Optional.",
+          "format": "int64"
+        },
+        "id": {
+          "type": "string",
+          "description": "A UUID or similar unique string that identifies this channel."
+        },
+        "kind": {
+          "type": "string",
+          "description": "Identifies this as a notification channel used to watch for changes to a resource, which is \"api#channel\".",
+          "default": "api#channel"
+        },
+        "params": {
+          "type": "object",
+          "description": "Additional parameters controlling delivery channel behavior. Optional.",
+          "additionalProperties": {
+            "type": "string",
+            "description": "Declares a new parameter by name."
+          }
+        },
+        "payload": {
+          "type": "boolean",
+          "description": "A Boolean value to indicate whether payload is wanted. Optional."
+        },
+        "resourceId": {
+          "type": "string",
+          "description": "An opaque ID that identifies the resource being watched on this channel. Stable across different API versions."
+        },
+        "resourceUri": {
+          "type": "string",
+          "description": "A version-specific identifier for the watched resource."
+        },
+        "token": {
+          "type": "string",
+          "description": "An arbitrary string delivered to the target address with each notification delivered over this channel. Optional."
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of delivery mechanism used for this channel. Valid values are \"web_hook\" (or \"webhook\"). Both values refer to a channel where Http requests are used to deliver messages."
+        }
+      }
+    },
+    "ChildList": {
+      "id": "ChildList",
+      "type": "object",
+      "description": "A list of children of a file.",
+      "properties": {
+        "etag": {
+          "type": "string",
+          "description": "The ETag of the list."
+        },
+        "items": {
+          "type": "array",
+          "description": "The list of children. If nextPageToken is populated, then this list may be incomplete and an additional page of results should be fetched.",
+          "items": {
+            "$ref": "ChildReference"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "This is always drive#childList.",
+          "default": "drive#childList"
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "A link to the next page of children."
+        },
+        "nextPageToken": {
+          "type": "string",
+          "description": "The page token for the next page of children. This will be absent if the end of the children list has been reached. If the token is rejected for any reason, it should be discarded, and pagination should be restarted from the first page of results."
+        },
+        "selfLink": {
+          "type": "string",
+          "description": "A link back to this list."
+        }
+      }
+    },
+    "ChildReference": {
+      "id": "ChildReference",
+      "type": "object",
+      "description": "A reference to a folder's child.",
+      "properties": {
+        "childLink": {
+          "type": "string",
+          "description": "A link to the child."
+        },
+        "id": {
+          "type": "string",
+          "description": "The ID of the child.",
+          "annotations": {
+            "required": [
+              "drive.children.insert"
+            ]
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "This is always drive#childReference.",
+          "default": "drive#childReference"
+        },
+        "selfLink": {
+          "type": "string",
+          "description": "A link back to this reference."
+        }
+      }
+    },
+    "Comment": {
+      "id": "Comment",
+      "type": "object",
+      "description": "A comment on a file in Google Drive.",
+      "properties": {
+        "anchor": {
+          "type": "string",
+          "description": "A region of the document represented as a JSON string. For details on defining anchor properties, refer to  Add comments and replies."
+        },
+        "author": {
+          "$ref": "User",
+          "description": "The author of the comment. The author's email address and permission ID will not be populated."
+        },
+        "commentId": {
+          "type": "string",
+          "description": "The ID of the comment."
+        },
+        "content": {
+          "type": "string",
+          "description": "The plain text content used to create this comment. This is not HTML safe and should only be used as a starting point to make edits to a comment's content.",
+          "annotations": {
+            "required": [
+              "drive.comments.insert",
+              "drive.comments.patch",
+              "drive.comments.update"
+            ]
+          }
+        },
+        "context": {
+          "type": "object",
+          "description": "The context of the file which is being commented on.",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "The MIME type of the context snippet."
+            },
+            "value": {
+              "type": "string",
+              "description": "Data representation of the segment of the file being commented on. In the case of a text file for example, this would be the actual text that the comment is about."
+            }
+          }
+        },
+        "createdDate": {
+          "type": "string",
+          "description": "The date when this comment was first created.",
+          "format": "date-time"
+        },
+        "deleted": {
+          "type": "boolean",
+          "description": "Whether this comment has been deleted. If a comment has been deleted the content will be cleared and this will only represent a comment that once existed."
+        },
+        "fileId": {
+          "type": "string",
+          "description": "The file which this comment is addressing."
+        },
+        "fileTitle": {
+          "type": "string",
+          "description": "The title of the file which this comment is addressing."
+        },
+        "htmlContent": {
+          "type": "string",
+          "description": "HTML formatted content for this comment."
+        },
+        "kind": {
+          "type": "string",
+          "description": "This is always drive#comment.",
+          "default": "drive#comment"
+        },
+        "modifiedDate": {
+          "type": "string",
+          "description": "The date when this comment or any of its replies were last modified.",
+          "format": "date-time"
+        },
+        "replies": {
+          "type": "array",
+          "description": "Replies to this post.",
+          "items": {
+            "$ref": "CommentReply"
+          }
+        },
+        "selfLink": {
+          "type": "string",
+          "description": "A link back to this comment."
+        },
+        "status": {
+          "type": "string",
+          "description": "The status of this comment. Status can be changed by posting a reply to a comment with the desired status.  \n- \"open\" - The comment is still open. \n- \"resolved\" - The comment has been resolved by one of its replies."
+        }
+      }
+    },
+    "CommentList": {
+      "id": "CommentList",
+      "type": "object",
+      "description": "A list of comments on a file in Google Drive.",
+      "properties": {
+        "items": {
+          "type": "array",
+          "description": "The list of comments. If nextPageToken is populated, then this list may be incomplete and an additional page of results should be fetched.",
+          "items": {
+            "$ref": "Comment"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "This is always drive#commentList.",
+          "default": "drive#commentList"
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "A link to the next page of comments."
+        },
+        "nextPageToken": {
+          "type": "string",
+          "description": "The page token for the next page of comments. This will be absent if the end of the comments list has been reached. If the token is rejected for any reason, it should be discarded, and pagination should be restarted from the first page of results."
+        },
+        "selfLink": {
+          "type": "string",
+          "description": "A link back to this list."
+        }
+      }
+    },
+    "CommentReply": {
+      "id": "CommentReply",
+      "type": "object",
+      "description": "A comment on a file in Google Drive.",
+      "properties": {
+        "author": {
+          "$ref": "User",
+          "description": "The author of the reply. The author's email address and permission ID will not be populated."
+        },
+        "content": {
+          "type": "string",
+          "description": "The plain text content used to create this reply. This is not HTML safe and should only be used as a starting point to make edits to a reply's content. This field is required on inserts if no verb is specified (resolve/reopen).",
+          "annotations": {
+            "required": [
+              "drive.replies.patch",
+              "drive.replies.update"
+            ]
+          }
+        },
+        "createdDate": {
+          "type": "string",
+          "description": "The date when this reply was first created.",
+          "format": "date-time"
+        },
+        "deleted": {
+          "type": "boolean",
+          "description": "Whether this reply has been deleted. If a reply has been deleted the content will be cleared and this will only represent a reply that once existed."
+        },
+        "htmlContent": {
+          "type": "string",
+          "description": "HTML formatted content for this reply."
+        },
+        "kind": {
+          "type": "string",
+          "description": "This is always drive#commentReply.",
+          "default": "drive#commentReply"
+        },
+        "modifiedDate": {
+          "type": "string",
+          "description": "The date when this reply was last modified.",
+          "format": "date-time"
+        },
+        "replyId": {
+          "type": "string",
+          "description": "The ID of the reply."
+        },
+        "verb": {
+          "type": "string",
+          "description": "The action this reply performed to the parent comment. When creating a new reply this is the action to be perform to the parent comment. Possible values are:  \n- \"resolve\" - To resolve a comment. \n- \"reopen\" - To reopen (un-resolve) a comment."
+        }
+      }
+    },
+    "CommentReplyList": {
+      "id": "CommentReplyList",
+      "type": "object",
+      "description": "A list of replies to a comment on a file in Google Drive.",
+      "properties": {
+        "items": {
+          "type": "array",
+          "description": "The list of replies. If nextPageToken is populated, then this list may be incomplete and an additional page of results should be fetched.",
+          "items": {
+            "$ref": "CommentReply"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "This is always drive#commentReplyList.",
+          "default": "drive#commentReplyList"
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "A link to the next page of replies."
+        },
+        "nextPageToken": {
+          "type": "string",
+          "description": "The page token for the next page of replies. This will be absent if the end of the replies list has been reached. If the token is rejected for any reason, it should be discarded, and pagination should be restarted from the first page of results."
+        },
+        "selfLink": {
+          "type": "string",
+          "description": "A link back to this list."
+        }
+      }
+    },
+    "ContentRestriction": {
+      "id": "ContentRestriction",
+      "type": "object",
+      "description": "A restriction for accessing the content of the file.",
+      "properties": {
+        "readOnly": {
+          "type": "boolean",
+          "description": "Whether the content of the file is read-only. If a file is read-only, a new revision of the file may not be added, comments may not be added or modified, and the title of the file may not be modified."
+        },
+        "reason": {
+          "type": "string",
+          "description": "Reason for why the content of the file is restricted. This is only mutable on requests that also set readOnly=true."
+        },
+        "restrictingUser": {
+          "$ref": "User",
+          "description": "The user who set the content restriction. Only populated if readOnly is true."
+        },
+        "restrictionDate": {
+          "type": "string",
+          "description": "The time at which the content restriction was set (formatted RFC 3339 timestamp). Only populated if readOnly is true.",
+          "format": "date-time"
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of the content restriction. Currently the only possible value is globalContentRestriction."
+        }
+      }
+    },
+    "Drive": {
+      "id": "Drive",
+      "type": "object",
+      "description": "Representation of a shared drive.",
+      "properties": {
+        "backgroundImageFile": {
+          "type": "object",
+          "description": "An image file and cropping parameters from which a background image for this shared drive is set. This is a write only field; it can only be set on drive.drives.update requests that don't set themeId. When specified, all fields of the backgroundImageFile must be set.",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of an image file in Google Drive to use for the background image."
+            },
+            "width": {
+              "type": "number",
+              "description": "The width of the cropped image in the closed range of 0 to 1. This value represents the width of the cropped image divided by the width of the entire image. The height is computed by applying a width to height aspect ratio of 80 to 9. The resulting image must be at least 1280 pixels wide and 144 pixels high.",
+              "format": "float"
+            },
+            "xCoordinate": {
+              "type": "number",
+              "description": "The X coordinate of the upper left corner of the cropping area in the background image. This is a value in the closed range of 0 to 1. This value represents the horizontal distance from the left side of the entire image to the left side of the cropping area divided by the width of the entire image.",
+              "format": "float"
+            },
+            "yCoordinate": {
+              "type": "number",
+              "description": "The Y coordinate of the upper left corner of the cropping area in the background image. This is a value in the closed range of 0 to 1. This value represents the vertical distance from the top side of the entire image to the top side of the cropping area divided by the height of the entire image.",
+              "format": "float"
+            }
+          }
+        },
+        "backgroundImageLink": {
+          "type": "string",
+          "description": "A short-lived link to this shared drive's background image."
+        },
+        "capabilities": {
+          "type": "object",
+          "description": "Capabilities the current user has on this shared drive.",
+          "properties": {
+            "canAddChildren": {
+              "type": "boolean",
+              "description": "Whether the current user can add children to folders in this shared drive."
+            },
+            "canChangeCopyRequiresWriterPermissionRestriction": {
+              "type": "boolean",
+              "description": "Whether the current user can change the copyRequiresWriterPermission restriction of this shared drive."
+            },
+            "canChangeDomainUsersOnlyRestriction": {
+              "type": "boolean",
+              "description": "Whether the current user can change the domainUsersOnly restriction of this shared drive."
+            },
+            "canChangeDriveBackground": {
+              "type": "boolean",
+              "description": "Whether the current user can change the background of this shared drive."
+            },
+            "canChangeDriveMembersOnlyRestriction": {
+              "type": "boolean",
+              "description": "Whether the current user can change the driveMembersOnly restriction of this shared drive."
+            },
+            "canComment": {
+              "type": "boolean",
+              "description": "Whether the current user can comment on files in this shared drive."
+            },
+            "canCopy": {
+              "type": "boolean",
+              "description": "Whether the current user can copy files in this shared drive."
+            },
+            "canDeleteChildren": {
+              "type": "boolean",
+              "description": "Whether the current user can delete children from folders in this shared drive."
+            },
+            "canDeleteDrive": {
+              "type": "boolean",
+              "description": "Whether the current user can delete this shared drive. Attempting to delete the shared drive may still fail if there are untrashed items inside the shared drive."
+            },
+            "canDownload": {
+              "type": "boolean",
+              "description": "Whether the current user can download files in this shared drive."
+            },
+            "canEdit": {
+              "type": "boolean",
+              "description": "Whether the current user can edit files in this shared drive"
+            },
+            "canListChildren": {
+              "type": "boolean",
+              "description": "Whether the current user can list the children of folders in this shared drive."
+            },
+            "canManageMembers": {
+              "type": "boolean",
+              "description": "Whether the current user can add members to this shared drive or remove them or change their role."
+            },
+            "canReadRevisions": {
+              "type": "boolean",
+              "description": "Whether the current user can read the revisions resource of files in this shared drive."
+            },
+            "canRename": {
+              "type": "boolean",
+              "description": "Whether the current user can rename files or folders in this shared drive."
+            },
+            "canRenameDrive": {
+              "type": "boolean",
+              "description": "Whether the current user can rename this shared drive."
+            },
+            "canResetDriveRestrictions": {
+              "type": "boolean",
+              "description": "Whether the current user can reset the shared drive restrictions to defaults."
+            },
+            "canShare": {
+              "type": "boolean",
+              "description": "Whether the current user can share files or folders in this shared drive."
+            },
+            "canTrashChildren": {
+              "type": "boolean",
+              "description": "Whether the current user can trash children from folders in this shared drive."
+            }
+          }
+        },
+        "colorRgb": {
+          "type": "string",
+          "description": "The color of this shared drive as an RGB hex string. It can only be set on a drive.drives.update request that does not set themeId."
+        },
+        "createdDate": {
+          "type": "string",
+          "description": "The time at which the shared drive was created (RFC 3339 date-time).",
+          "format": "date-time"
+        },
+        "hidden": {
+          "type": "boolean",
+          "description": "Whether the shared drive is hidden from default view."
+        },
+        "id": {
+          "type": "string",
+          "description": "The ID of this shared drive which is also the ID of the top level folder of this shared drive."
+        },
+        "kind": {
+          "type": "string",
+          "description": "This is always drive#drive",
+          "default": "drive#drive"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of this shared drive.",
+          "annotations": {
+            "required": [
+              "drive.drives.insert"
+            ]
+          }
+        },
+        "orgUnitId": {
+          "type": "string",
+          "description": "The organizational unit of this shared drive. This field is only populated on drives.list responses when the useDomainAdminAccess parameter is set to true."
+        },
+        "restrictions": {
+          "type": "object",
+          "description": "A set of restrictions that apply to this shared drive or items inside this shared drive.",
+          "properties": {
+            "adminManagedRestrictions": {
+              "type": "boolean",
+              "description": "Whether administrative privileges on this shared drive are required to modify restrictions."
+            },
+            "copyRequiresWriterPermission": {
+              "type": "boolean",
+              "description": "Whether the options to copy, print, or download files inside this shared drive, should be disabled for readers and commenters. When this restriction is set to true, it will override the similarly named field to true for any file inside this shared drive."
+            },
+            "domainUsersOnly": {
+              "type": "boolean",
+              "description": "Whether access to this shared drive and items inside this shared drive is restricted to users of the domain to which this shared drive belongs. This restriction may be overridden by other sharing policies controlled outside of this shared drive."
+            },
+            "driveMembersOnly": {
+              "type": "boolean",
+              "description": "Whether access to items inside this shared drive is restricted to its members."
+            }
+          }
+        },
+        "themeId": {
+          "type": "string",
+          "description": "The ID of the theme from which the background image and color will be set. The set of possible driveThemes can be retrieved from a drive.about.get response. When not specified on a drive.drives.insert request, a random theme is chosen from which the background image and color are set. This is a write-only field; it can only be set on requests that don't set colorRgb or backgroundImageFile."
+        }
+      }
+    },
+    "DriveList": {
+      "id": "DriveList",
+      "type": "object",
+      "description": "A list of shared drives.",
+      "properties": {
+        "items": {
+          "type": "array",
+          "description": "The list of shared drives. If nextPageToken is populated, then this list may be incomplete and an additional page of results should be fetched.",
+          "items": {
+            "$ref": "Drive"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "This is always drive#driveList",
+          "default": "drive#driveList"
+        },
+        "nextPageToken": {
+          "type": "string",
+          "description": "The page token for the next page of shared drives. This will be absent if the end of the list has been reached. If the token is rejected for any reason, it should be discarded, and pagination should be restarted from the first page of results."
+        }
+      }
+    },
+    "File": {
+      "id": "File",
+      "type": "object",
+      "description": "The metadata for a file.",
+      "properties": {
+        "alternateLink": {
+          "type": "string",
+          "description": "A link for opening the file in a relevant Google editor or viewer."
+        },
+        "appDataContents": {
+          "type": "boolean",
+          "description": "Whether this file is in the Application Data folder."
+        },
+        "canComment": {
+          "type": "boolean",
+          "description": "Deprecated: use capabilities/canComment."
+        },
+        "canReadRevisions": {
+          "type": "boolean",
+          "description": "Deprecated: use capabilities/canReadRevisions."
+        },
+        "capabilities": {
+          "type": "object",
+          "description": "Capabilities the current user has on this file. Each capability corresponds to a fine-grained action that a user may take.",
+          "properties": {
+            "canAcceptOwnership": {
+              "type": "boolean",
+              "description": "Whether the current user is the pending owner of the file. Not populated for shared drive files."
+            },
+            "canAddChildren": {
+              "type": "boolean",
+              "description": "Whether the current user can add children to this folder. This is always false when the item is not a folder."
+            },
+            "canAddFolderFromAnotherDrive": {
+              "type": "boolean",
+              "description": "Whether the current user can add a folder from another drive (different shared drive or My Drive) to this folder. This is false when the item is not a folder. Only populated for items in shared drives."
+            },
+            "canAddMyDriveParent": {
+              "type": "boolean",
+              "description": "Whether the current user can add a parent for the item without removing an existing parent in the same request. Not populated for shared drive files."
+            },
+            "canChangeCopyRequiresWriterPermission": {
+              "type": "boolean",
+              "description": "Whether the current user can change the copyRequiresWriterPermission restriction of this file."
+            },
+            "canChangeRestrictedDownload": {
+              "type": "boolean",
+              "description": "Deprecated"
+            },
+            "canChangeSecurityUpdateEnabled": {
+              "type": "boolean",
+              "description": "Whether the current user can change the securityUpdateEnabled field on link share metadata."
+            },
+            "canComment": {
+              "type": "boolean",
+              "description": "Whether the current user can comment on this file."
+            },
+            "canCopy": {
+              "type": "boolean",
+              "description": "Whether the current user can copy this file. For an item in a shared drive, whether the current user can copy non-folder descendants of this item, or this item itself if it is not a folder."
+            },
+            "canDelete": {
+              "type": "boolean",
+              "description": "Whether the current user can delete this file."
+            },
+            "canDeleteChildren": {
+              "type": "boolean",
+              "description": "Whether the current user can delete children of this folder. This is false when the item is not a folder. Only populated for items in shared drives."
+            },
+            "canDownload": {
+              "type": "boolean",
+              "description": "Whether the current user can download this file."
+            },
+            "canEdit": {
+              "type": "boolean",
+              "description": "Whether the current user can edit this file. Other factors may limit the type of changes a user can make to a file. For example, see canChangeCopyRequiresWriterPermission or canModifyContent."
+            },
+            "canListChildren": {
+              "type": "boolean",
+              "description": "Whether the current user can list the children of this folder. This is always false when the item is not a folder."
+            },
+            "canModifyContent": {
+              "type": "boolean",
+              "description": "Whether the current user can modify the content of this file."
+            },
+            "canModifyContentRestriction": {
+              "type": "boolean",
+              "description": "Whether the current user can modify restrictions on content of this file."
+            },
+            "canMoveChildrenOutOfDrive": {
+              "type": "boolean",
+              "description": "Whether the current user can move children of this folder outside of the shared drive. This is false when the item is not a folder. Only populated for items in shared drives."
+            },
+            "canMoveChildrenOutOfTeamDrive": {
+              "type": "boolean",
+              "description": "Deprecated - use canMoveChildrenOutOfDrive instead."
+            },
+            "canMoveChildrenWithinDrive": {
+              "type": "boolean",
+              "description": "Whether the current user can move children of this folder within this drive. This is false when the item is not a folder. Note that a request to move the child may still fail depending on the current user's access to the child and to the destination folder."
+            },
+            "canMoveChildrenWithinTeamDrive": {
+              "type": "boolean",
+              "description": "Deprecated - use canMoveChildrenWithinDrive instead."
+            },
+            "canMoveItemIntoTeamDrive": {
+              "type": "boolean",
+              "description": "Deprecated - use canMoveItemOutOfDrive instead."
+            },
+            "canMoveItemOutOfDrive": {
+              "type": "boolean",
+              "description": "Whether the current user can move this item outside of this drive by changing its parent. Note that a request to change the parent of the item may still fail depending on the new parent that is being added."
+            },
+            "canMoveItemOutOfTeamDrive": {
+              "type": "boolean",
+              "description": "Deprecated - use canMoveItemOutOfDrive instead."
+            },
+            "canMoveItemWithinDrive": {
+              "type": "boolean",
+              "description": "Whether the current user can move this item within this drive. Note that a request to change the parent of the item may still fail depending on the new parent that is being added and the parent that is being removed."
+            },
+            "canMoveItemWithinTeamDrive": {
+              "type": "boolean",
+              "description": "Deprecated - use canMoveItemWithinDrive instead."
+            },
+            "canMoveTeamDriveItem": {
+              "type": "boolean",
+              "description": "Deprecated - use canMoveItemWithinDrive or canMoveItemOutOfDrive instead."
+            },
+            "canReadDrive": {
+              "type": "boolean",
+              "description": "Whether the current user can read the shared drive to which this file belongs. Only populated for items in shared drives."
+            },
+            "canReadRevisions": {
+              "type": "boolean",
+              "description": "Whether the current user can read the revisions resource of this file. For a shared drive item, whether revisions of non-folder descendants of this item, or this item itself if it is not a folder, can be read."
+            },
+            "canReadTeamDrive": {
+              "type": "boolean",
+              "description": "Deprecated - use canReadDrive instead."
+            },
+            "canRemoveChildren": {
+              "type": "boolean",
+              "description": "Whether the current user can remove children from this folder. This is always false when the item is not a folder. For a folder in a shared drive, use canDeleteChildren or canTrashChildren instead."
+            },
+            "canRemoveMyDriveParent": {
+              "type": "boolean",
+              "description": "Whether the current user can remove a parent from the item without adding another parent in the same request. Not populated for shared drive files."
+            },
+            "canRename": {
+              "type": "boolean",
+              "description": "Whether the current user can rename this file."
+            },
+            "canShare": {
+              "type": "boolean",
+              "description": "Whether the current user can modify the sharing settings for this file."
+            },
+            "canTrash": {
+              "type": "boolean",
+              "description": "Whether the current user can move this file to trash."
+            },
+            "canTrashChildren": {
+              "type": "boolean",
+              "description": "Whether the current user can trash children of this folder. This is false when the item is not a folder. Only populated for items in shared drives."
+            },
+            "canUntrash": {
+              "type": "boolean",
+              "description": "Whether the current user can restore this file from trash."
+            }
+          }
+        },
+        "contentRestrictions": {
+          "type": "array",
+          "description": "Restrictions for accessing the content of the file. Only populated if such a restriction exists.",
+          "items": {
+            "$ref": "ContentRestriction"
+          }
+        },
+        "copyRequiresWriterPermission": {
+          "type": "boolean",
+          "description": "Whether the options to copy, print, or download this file, should be disabled for readers and commenters."
+        },
+        "copyable": {
+          "type": "boolean",
+          "description": "Deprecated: use capabilities/canCopy."
+        },
+        "createdDate": {
+          "type": "string",
+          "description": "Create time for this file (formatted RFC 3339 timestamp).",
+          "format": "date-time"
+        },
+        "defaultOpenWithLink": {
+          "type": "string",
+          "description": "A link to open this file with the user's default app for this file. Only populated when the drive.apps.readonly scope is used."
+        },
+        "description": {
+          "type": "string",
+          "description": "A short description of the file."
+        },
+        "downloadUrl": {
+          "type": "string",
+          "description": "Short lived download URL for the file. This field is only populated for files with content stored in Google Drive; it is not populated for Docs Editors or shortcut files."
+        },
+        "driveId": {
+          "type": "string",
+          "description": "ID of the shared drive the file resides in. Only populated for items in shared drives."
+        },
+        "editable": {
+          "type": "boolean",
+          "description": "Deprecated: use capabilities/canEdit."
+        },
+        "embedLink": {
+          "type": "string",
+          "description": "A link for embedding the file."
+        },
+        "etag": {
+          "type": "string",
+          "description": "ETag of the file."
+        },
+        "explicitlyTrashed": {
+          "type": "boolean",
+          "description": "Whether this file has been explicitly trashed, as opposed to recursively trashed."
+        },
+        "exportLinks": {
+          "type": "object",
+          "description": "Links for exporting Docs Editors files to specific formats.",
+          "readOnly": true,
+          "additionalProperties": {
+            "type": "string",
+            "description": "A mapping from export format to URL"
+          }
+        },
+        "fileExtension": {
+          "type": "string",
+          "description": "The final component of fullFileExtension with trailing text that does not appear to be part of the extension removed. This field is only populated for files with content stored in Google Drive; it is not populated for Docs Editors or shortcut files."
+        },
+        "fileSize": {
+          "type": "string",
+          "description": "The size of the file in bytes. This field is populated for files with content stored in Google Drive and for files in Docs Editors; it is not populated for shortcut files.",
+          "format": "int64"
+        },
+        "folderColorRgb": {
+          "type": "string",
+          "description": "Folder color as an RGB hex string if the file is a folder or a shortcut to a folder. The list of supported colors is available in the folderColorPalette field of the About resource. If an unsupported color is specified, it will be changed to the closest color in the palette."
+        },
+        "fullFileExtension": {
+          "type": "string",
+          "description": "The full file extension; extracted from the title. May contain multiple concatenated extensions, such as \"tar.gz\". Removing an extension from the title does not clear this field; however, changing the extension on the title does update this field. This field is only populated for files with content stored in Google Drive; it is not populated for Docs Editors or shortcut files."
+        },
+        "hasAugmentedPermissions": {
+          "type": "boolean",
+          "description": "Whether there are permissions directly on this file. This field is only populated for items in shared drives."
+        },
+        "hasThumbnail": {
+          "type": "boolean",
+          "description": "Whether this file has a thumbnail. This does not indicate whether the requesting app has access to the thumbnail. To check access, look for the presence of the thumbnailLink field."
+        },
+        "headRevisionId": {
+          "type": "string",
+          "description": "The ID of the file's head revision. This field is only populated for files with content stored in Google Drive; it is not populated for Docs Editors or shortcut files."
+        },
+        "iconLink": {
+          "type": "string",
+          "description": "A link to the file's icon."
+        },
+        "id": {
+          "type": "string",
+          "description": "The ID of the file."
+        },
+        "imageMediaMetadata": {
+          "type": "object",
+          "description": "Metadata about image media. This will only be present for image types, and its contents will depend on what can be parsed from the image content.",
+          "properties": {
+            "aperture": {
+              "type": "number",
+              "description": "The aperture used to create the photo (f-number).",
+              "format": "float"
+            },
+            "cameraMake": {
+              "type": "string",
+              "description": "The make of the camera used to create the photo."
+            },
+            "cameraModel": {
+              "type": "string",
+              "description": "The model of the camera used to create the photo."
+            },
+            "colorSpace": {
+              "type": "string",
+              "description": "The color space of the photo."
+            },
+            "date": {
+              "type": "string",
+              "description": "The date and time the photo was taken (EXIF format timestamp)."
+            },
+            "exposureBias": {
+              "type": "number",
+              "description": "The exposure bias of the photo (APEX value).",
+              "format": "float"
+            },
+            "exposureMode": {
+              "type": "string",
+              "description": "The exposure mode used to create the photo."
+            },
+            "exposureTime": {
+              "type": "number",
+              "description": "The length of the exposure, in seconds.",
+              "format": "float"
+            },
+            "flashUsed": {
+              "type": "boolean",
+              "description": "Whether a flash was used to create the photo."
+            },
+            "focalLength": {
+              "type": "number",
+              "description": "The focal length used to create the photo, in millimeters.",
+              "format": "float"
+            },
+            "height": {
+              "type": "integer",
+              "description": "The height of the image in pixels.",
+              "format": "int32"
+            },
+            "isoSpeed": {
+              "type": "integer",
+              "description": "The ISO speed used to create the photo.",
+              "format": "int32"
+            },
+            "lens": {
+              "type": "string",
+              "description": "The lens used to create the photo."
+            },
+            "location": {
+              "type": "object",
+              "description": "Geographic location information stored in the image.",
+              "properties": {
+                "altitude": {
+                  "type": "number",
+                  "description": "The altitude stored in the image.",
+                  "format": "double"
+                },
+                "latitude": {
+                  "type": "number",
+                  "description": "The latitude stored in the image.",
+                  "format": "double"
+                },
+                "longitude": {
+                  "type": "number",
+                  "description": "The longitude stored in the image.",
+                  "format": "double"
+                }
+              }
+            },
+            "maxApertureValue": {
+              "type": "number",
+              "description": "The smallest f-number of the lens at the focal length used to create the photo (APEX value).",
+              "format": "float"
+            },
+            "meteringMode": {
+              "type": "string",
+              "description": "The metering mode used to create the photo."
+            },
+            "rotation": {
+              "type": "integer",
+              "description": "The number of clockwise 90 degree rotations applied from the image's original orientation.",
+              "format": "int32"
+            },
+            "sensor": {
+              "type": "string",
+              "description": "The type of sensor used to create the photo."
+            },
+            "subjectDistance": {
+              "type": "integer",
+              "description": "The distance to the subject of the photo, in meters.",
+              "format": "int32"
+            },
+            "whiteBalance": {
+              "type": "string",
+              "description": "The white balance mode used to create the photo."
+            },
+            "width": {
+              "type": "integer",
+              "description": "The width of the image in pixels.",
+              "format": "int32"
+            }
+          }
+        },
+        "indexableText": {
+          "type": "object",
+          "description": "Indexable text attributes for the file (can only be written)",
+          "properties": {
+            "text": {
+              "type": "string",
+              "description": "The text to be indexed for this file."
+            }
+          }
+        },
+        "isAppAuthorized": {
+          "type": "boolean",
+          "description": "Whether the file was created or opened by the requesting app."
+        },
+        "kind": {
+          "type": "string",
+          "description": "The type of file. This is always drive#file.",
+          "default": "drive#file"
+        },
+        "labels": {
+          "type": "object",
+          "description": "A group of labels for the file.",
+          "properties": {
+            "hidden": {
+              "type": "boolean",
+              "description": "Deprecated."
+            },
+            "modified": {
+              "type": "boolean",
+              "description": "Whether the file has been modified by this user."
+            },
+            "restricted": {
+              "type": "boolean",
+              "description": "Deprecated - use copyRequiresWriterPermission instead."
+            },
+            "starred": {
+              "type": "boolean",
+              "description": "Whether this file is starred by the user."
+            },
+            "trashed": {
+              "type": "boolean",
+              "description": "Whether the file has been trashed, either explicitly or from a trashed parent folder. Only the owner may trash a file. The trashed item is excluded from all files.list responses returned for any user who does not own the file. However, all users with access to the file can see the trashed item metadata in an API response. All users with access can copy, download, export, and share the file."
+            },
+            "viewed": {
+              "type": "boolean",
+              "description": "Whether this file has been viewed by this user."
+            }
+          }
+        },
+        "lastModifyingUser": {
+          "$ref": "User",
+          "description": "The last user to modify this file."
+        },
+        "lastModifyingUserName": {
+          "type": "string",
+          "description": "Name of the last user to modify this file."
+        },
+        "lastViewedByMeDate": {
+          "type": "string",
+          "description": "Last time this file was viewed by the user (formatted RFC 3339 timestamp).",
+          "format": "date-time"
+        },
+        "linkShareMetadata": {
+          "type": "object",
+          "description": "Contains details about the link URLs that clients are using to refer to this item.",
+          "properties": {
+            "securityUpdateEligible": {
+              "type": "boolean",
+              "description": "Whether the file is eligible for security update."
+            },
+            "securityUpdateEnabled": {
+              "type": "boolean",
+              "description": "Whether the security update is enabled for this file."
+            }
+          }
+        },
+        "markedViewedByMeDate": {
+          "type": "string",
+          "description": "Deprecated.",
+          "format": "date-time"
+        },
+        "md5Checksum": {
+          "type": "string",
+          "description": "An MD5 checksum for the content of this file. This field is only populated for files with content stored in Google Drive; it is not populated for Docs Editors or shortcut files."
+        },
+        "mimeType": {
+          "type": "string",
+          "description": "The MIME type of the file. This is only mutable on update when uploading new content. This field can be left blank, and the mimetype will be determined from the uploaded content's MIME type."
+        },
+        "modifiedByMeDate": {
+          "type": "string",
+          "description": "Last time this file was modified by the user (formatted RFC 3339 timestamp). Note that setting modifiedDate will also update the modifiedByMe date for the user which set the date.",
+          "format": "date-time"
+        },
+        "modifiedDate": {
+          "type": "string",
+          "description": "Last time this file was modified by anyone (formatted RFC 3339 timestamp). This is only mutable on update when the setModifiedDate parameter is set.",
+          "format": "date-time"
+        },
+        "openWithLinks": {
+          "type": "object",
+          "description": "A map of the id of each of the user's apps to a link to open this file with that app. Only populated when the drive.apps.readonly scope is used.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "originalFilename": {
+          "type": "string",
+          "description": "The original filename of the uploaded content if available, or else the original value of the title field. This is only available for files with binary content in Google Drive."
+        },
+        "ownedByMe": {
+          "type": "boolean",
+          "description": "Whether the file is owned by the current user. Not populated for items in shared drives."
+        },
+        "ownerNames": {
+          "type": "array",
+          "description": "Name(s) of the owner(s) of this file. Not populated for items in shared drives.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "owners": {
+          "type": "array",
+          "description": "The owner of this file. Only certain legacy files may have more than one owner. This field isn't populated for items in shared drives.",
+          "items": {
+            "$ref": "User"
+          }
+        },
+        "parents": {
+          "type": "array",
+          "description": "Collection of parent folders which contain this file.\nIf not specified as part of an insert request, the file will be placed directly in the user's My Drive folder. If not specified as part of a copy request, the file will inherit any discoverable parents of the source file. Update requests can also use the addParents and removeParents parameters to modify the parents list.",
+          "items": {
+            "$ref": "ParentReference"
+          }
+        },
+        "permissionIds": {
+          "type": "array",
+          "description": "List of permission IDs for users with access to this file.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "permissions": {
+          "type": "array",
+          "description": "The list of permissions for users with access to this file. Not populated for items in shared drives.",
+          "items": {
+            "$ref": "Permission"
+          }
+        },
+        "properties": {
+          "type": "array",
+          "description": "The list of properties.",
+          "items": {
+            "$ref": "Property"
+          }
+        },
+        "quotaBytesUsed": {
+          "type": "string",
+          "description": "The number of quota bytes used by this file.",
+          "format": "int64"
+        },
+        "resourceKey": {
+          "type": "string",
+          "description": "A key needed to access the item via a shared link."
+        },
+        "selfLink": {
+          "type": "string",
+          "description": "A link back to this file."
+        },
+        "shareable": {
+          "type": "boolean",
+          "description": "Deprecated: use capabilities/canShare."
+        },
+        "shared": {
+          "type": "boolean",
+          "description": "Whether the file has been shared. Not populated for items in shared drives."
+        },
+        "sharedWithMeDate": {
+          "type": "string",
+          "description": "Time at which this file was shared with the user (formatted RFC 3339 timestamp).",
+          "format": "date-time"
+        },
+        "sharingUser": {
+          "$ref": "User",
+          "description": "User that shared the item with the current user, if available."
+        },
+        "shortcutDetails": {
+          "type": "object",
+          "description": "Shortcut file details. Only populated for shortcut files, which have the mimeType field set to application/vnd.google-apps.shortcut.",
+          "properties": {
+            "targetId": {
+              "type": "string",
+              "description": "The ID of the file that this shortcut points to."
+            },
+            "targetMimeType": {
+              "type": "string",
+              "description": "The MIME type of the file that this shortcut points to. The value of this field is a snapshot of the target's MIME type, captured when the shortcut is created."
+            },
+            "targetResourceKey": {
+              "type": "string",
+              "description": "The ResourceKey for the target file."
+            }
+          }
+        },
+        "spaces": {
+          "type": "array",
+          "description": "The list of spaces which contain the file. Supported values are 'drive', 'appDataFolder' and 'photos'.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "teamDriveId": {
+          "type": "string",
+          "description": "Deprecated - use driveId instead."
+        },
+        "thumbnail": {
+          "type": "object",
+          "description": "A thumbnail for the file. This will only be used if a standard thumbnail cannot be generated.",
+          "properties": {
+            "image": {
+              "type": "string",
+              "description": "The URL-safe Base64 encoded bytes of the thumbnail image. It should conform to RFC 4648 section 5.",
+              "format": "byte"
+            },
+            "mimeType": {
+              "type": "string",
+              "description": "The MIME type of the thumbnail."
+            }
+          }
+        },
+        "thumbnailLink": {
+          "type": "string",
+          "description": "A short-lived link to the file's thumbnail. Typically lasts on the order of hours. Only populated when the requesting app can access the file's content. If the file isn't shared publicly, the URL returned in Files.thumbnailLink must be fetched using a credentialed request."
+        },
+        "thumbnailVersion": {
+          "type": "string",
+          "description": "The thumbnail version for use in thumbnail cache invalidation.",
+          "format": "int64"
+        },
+        "title": {
+          "type": "string",
+          "description": "The title of this file. Note that for immutable items such as the top level folders of shared drives, My Drive root folder, and Application Data folder the title is constant."
+        },
+        "trashedDate": {
+          "type": "string",
+          "description": "The time that the item was trashed (formatted RFC 3339 timestamp). Only populated for items in shared drives.",
+          "format": "date-time"
+        },
+        "trashingUser": {
+          "$ref": "User",
+          "description": "If the file has been explicitly trashed, the user who trashed it. Only populated for items in shared drives."
+        },
+        "userPermission": {
+          "$ref": "Permission",
+          "description": "The permissions for the authenticated user on this file."
+        },
+        "version": {
+          "type": "string",
+          "description": "A monotonically increasing version number for the file. This reflects every change made to the file on the server, even those not visible to the requesting user.",
+          "format": "int64"
+        },
+        "videoMediaMetadata": {
+          "type": "object",
+          "description": "Metadata about video media. This will only be present for video types.",
+          "properties": {
+            "durationMillis": {
+              "type": "string",
+              "description": "The duration of the video in milliseconds.",
+              "format": "int64"
+            },
+            "height": {
+              "type": "integer",
+              "description": "The height of the video in pixels.",
+              "format": "int32"
+            },
+            "width": {
+              "type": "integer",
+              "description": "The width of the video in pixels.",
+              "format": "int32"
+            }
+          }
+        },
+        "webContentLink": {
+          "type": "string",
+          "description": "A link for downloading the content of the file in a browser using cookie based authentication. In cases where the content is shared publicly, the content can be downloaded without any credentials."
+        },
+        "webViewLink": {
+          "type": "string",
+          "description": "A link only available on public folders for viewing their static web assets (HTML, CSS, JS, etc) via Google Drive's Website Hosting."
+        },
+        "writersCanShare": {
+          "type": "boolean",
+          "description": "Whether writers can share the document with other users. Not populated for items in shared drives."
+        }
+      }
+    },
+    "FileList": {
+      "id": "FileList",
+      "type": "object",
+      "description": "A list of files.",
+      "properties": {
+        "etag": {
+          "type": "string",
+          "description": "The ETag of the list."
+        },
+        "incompleteSearch": {
+          "type": "boolean",
+          "description": "Whether the search process was incomplete. If true, then some search results may be missing, since all documents were not searched. This may occur when searching multiple drives with the \"allDrives\" corpora, but all corpora could not be searched. When this happens, it is suggested that clients narrow their query by choosing a different corpus such as \"default\" or \"drive\"."
+        },
+        "items": {
+          "type": "array",
+          "description": "The list of files. If nextPageToken is populated, then this list may be incomplete and an additional page of results should be fetched.",
+          "items": {
+            "$ref": "File"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "This is always drive#fileList.",
+          "default": "drive#fileList"
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "A link to the next page of files."
+        },
+        "nextPageToken": {
+          "type": "string",
+          "description": "The page token for the next page of files. This will be absent if the end of the files list has been reached. If the token is rejected for any reason, it should be discarded, and pagination should be restarted from the first page of results."
+        },
+        "selfLink": {
+          "type": "string",
+          "description": "A link back to this list."
+        }
+      }
+    },
+    "GeneratedIds": {
+      "id": "GeneratedIds",
+      "type": "object",
+      "description": "A list of generated IDs which can be provided in insert requests",
+      "properties": {
+        "ids": {
+          "type": "array",
+          "description": "The IDs generated for the requesting user in the specified space.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "This is always drive#generatedIds",
+          "default": "drive#generatedIds"
+        },
+        "space": {
+          "type": "string",
+          "description": "The type of file that can be created with these IDs."
+        }
+      }
+    },
+    "ParentList": {
+      "id": "ParentList",
+      "type": "object",
+      "description": "A list of a file's parents.",
+      "properties": {
+        "etag": {
+          "type": "string",
+          "description": "The ETag of the list."
+        },
+        "items": {
+          "type": "array",
+          "description": "The list of parents.",
+          "items": {
+            "$ref": "ParentReference"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "This is always drive#parentList.",
+          "default": "drive#parentList"
+        },
+        "selfLink": {
+          "type": "string",
+          "description": "A link back to this list."
+        }
+      }
+    },
+    "ParentReference": {
+      "id": "ParentReference",
+      "type": "object",
+      "description": "A reference to a file's parent.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The ID of the parent.",
+          "annotations": {
+            "required": [
+              "drive.parents.insert"
+            ]
+          }
+        },
+        "isRoot": {
+          "type": "boolean",
+          "description": "Whether or not the parent is the root folder."
+        },
+        "kind": {
+          "type": "string",
+          "description": "This is always drive#parentReference.",
+          "default": "drive#parentReference"
+        },
+        "parentLink": {
+          "type": "string",
+          "description": "A link to the parent."
+        },
+        "selfLink": {
+          "type": "string",
+          "description": "A link back to this reference."
+        }
+      }
+    },
+    "Permission": {
+      "id": "Permission",
+      "type": "object",
+      "description": "A permission for a file.",
+      "properties": {
+        "additionalRoles": {
+          "type": "array",
+          "description": "Additional roles for this user. Only commenter is currently allowed, though more may be supported in the future.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "authKey": {
+          "type": "string",
+          "description": "Deprecated."
+        },
+        "deleted": {
+          "type": "boolean",
+          "description": "Whether the account associated with this permission has been deleted. This field only pertains to user and group permissions."
+        },
+        "domain": {
+          "type": "string",
+          "description": "The domain name of the entity this permission refers to. This is an output-only field which is present when the permission type is user, group or domain."
+        },
+        "emailAddress": {
+          "type": "string",
+          "description": "The email address of the user or group this permission refers to. This is an output-only field which is present when the permission type is user or group."
+        },
+        "etag": {
+          "type": "string",
+          "description": "The ETag of the permission."
+        },
+        "expirationDate": {
+          "type": "string",
+          "description": "The time at which this permission will expire (RFC 3339 date-time). Expiration dates have the following restrictions:  \n- They cannot be set on shared drive items \n- They can only be set on user and group permissions \n- The date must be in the future \n- The date cannot be more than a year in the future \n- The date can only be set on drive.permissions.update or drive.permissions.patch requests",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string",
+          "description": "The ID of the user this permission refers to, and identical to the permissionId in the About and Files resources. When making a drive.permissions.insert request, exactly one of the id or value fields must be specified unless the permission type is anyone, in which case both id and value are ignored."
+        },
+        "kind": {
+          "type": "string",
+          "description": "This is always drive#permission.",
+          "default": "drive#permission"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name for this permission."
+        },
+        "pendingOwner": {
+          "type": "boolean",
+          "description": "Whether the account associated with this permission is a pending owner. Only populated for user type permissions for files that are not in a shared drive."
+        },
+        "permissionDetails": {
+          "type": "array",
+          "description": "Details of whether the permissions on this shared drive item are inherited or directly on this item. This is an output-only field which is present only for shared drive items.",
+          "readOnly": true,
+          "items": {
+            "type": "object",
+            "properties": {
+              "additionalRoles": {
+                "type": "array",
+                "description": "Additional roles for this user. Only commenter is currently possible, though more may be supported in the future.",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "inherited": {
+                "type": "boolean",
+                "description": "Whether this permission is inherited. This field is always populated. This is an output-only field."
+              },
+              "inheritedFrom": {
+                "type": "string",
+                "description": "The ID of the item from which this permission is inherited. This is an output-only field."
+              },
+              "permissionType": {
+                "type": "string",
+                "description": "The permission type for this user. While new values may be added in future, the following are currently possible:  \n- file \n- member"
+              },
+              "role": {
+                "type": "string",
+                "description": "The primary role for this user. While new values may be added in the future, the following are currently possible:  \n- organizer \n- fileOrganizer \n- writer \n- reader"
+              }
+            }
+          }
+        },
+        "photoLink": {
+          "type": "string",
+          "description": "A link to the profile photo, if available."
+        },
+        "role": {
+          "type": "string",
+          "description": "The primary role for this user. While new values may be supported in the future, the following are currently allowed:  \n- owner \n- organizer \n- fileOrganizer \n- writer \n- reader",
+          "annotations": {
+            "required": [
+              "drive.permissions.insert"
+            ]
+          }
+        },
+        "selfLink": {
+          "type": "string",
+          "description": "A link back to this permission."
+        },
+        "teamDrivePermissionDetails": {
+          "type": "array",
+          "description": "Deprecated - use permissionDetails instead.",
+          "readOnly": true,
+          "items": {
+            "type": "object",
+            "properties": {
+              "additionalRoles": {
+                "type": "array",
+                "description": "Deprecated - use permissionDetails/additionalRoles instead.",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "inherited": {
+                "type": "boolean",
+                "description": "Deprecated - use permissionDetails/inherited instead."
+              },
+              "inheritedFrom": {
+                "type": "string",
+                "description": "Deprecated - use permissionDetails/inheritedFrom instead."
+              },
+              "role": {
+                "type": "string",
+                "description": "Deprecated - use permissionDetails/role instead."
+              },
+              "teamDrivePermissionType": {
+                "type": "string",
+                "description": "Deprecated - use permissionDetails/permissionType instead."
+              }
+            }
+          }
+        },
+        "type": {
+          "type": "string",
+          "description": "The account type. Allowed values are:  \n- user \n- group \n- domain \n- anyone",
+          "annotations": {
+            "required": [
+              "drive.permissions.insert"
+            ]
+          }
+        },
+        "value": {
+          "type": "string",
+          "description": "The email address or domain name for the entity. This is used during inserts and is not populated in responses. When making a drive.permissions.insert request, exactly one of the id or value fields must be specified unless the permission type is anyone, in which case both id and value are ignored."
+        },
+        "view": {
+          "type": "string",
+          "description": "Indicates the view for this permission. Only populated for permissions that belong to a view. published is the only supported value."
+        },
+        "withLink": {
+          "type": "boolean",
+          "description": "Whether the link is required for this permission."
+        }
+      }
+    },
+    "PermissionId": {
+      "id": "PermissionId",
+      "type": "object",
+      "description": "An ID for a user or group as seen in Permission items.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The permission ID."
+        },
+        "kind": {
+          "type": "string",
+          "description": "This is always drive#permissionId.",
+          "default": "drive#permissionId"
+        }
+      }
+    },
+    "PermissionList": {
+      "id": "PermissionList",
+      "type": "object",
+      "description": "A list of permissions associated with a file.",
+      "properties": {
+        "etag": {
+          "type": "string",
+          "description": "The ETag of the list."
+        },
+        "items": {
+          "type": "array",
+          "description": "The list of permissions.",
+          "items": {
+            "$ref": "Permission"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "This is always drive#permissionList.",
+          "default": "drive#permissionList"
+        },
+        "nextPageToken": {
+          "type": "string",
+          "description": "The page token for the next page of permissions. This field will be absent if the end of the permissions list has been reached. If the token is rejected for any reason, it should be discarded, and pagination should be restarted from the first page of results."
+        },
+        "selfLink": {
+          "type": "string",
+          "description": "A link back to this list."
+        }
+      }
+    },
+    "Property": {
+      "id": "Property",
+      "type": "object",
+      "description": "A key-value pair attached to a file that is either public or private to an application.\nThe following limits apply to file properties:  \n- Maximum of 100 properties total per file\n- Maximum of 30 private properties per app\n- Maximum of 30 public properties\n- Maximum of 124 bytes size limit on (key + value) string in UTF-8 encoding for a single property.",
+      "properties": {
+        "etag": {
+          "type": "string",
+          "description": "ETag of the property."
+        },
+        "key": {
+          "type": "string",
+          "description": "The key of this property.",
+          "annotations": {
+            "required": [
+              "drive.properties.insert"
+            ]
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "This is always drive#property.",
+          "default": "drive#property"
+        },
+        "selfLink": {
+          "type": "string",
+          "description": "The link back to this property."
+        },
+        "value": {
+          "type": "string",
+          "description": "The value of this property."
+        },
+        "visibility": {
+          "type": "string",
+          "description": "The visibility of this property. Allowed values are PRIVATE and PUBLIC. (Default: PRIVATE). Private properties can only be retrieved using an authenticated request. An authenticated request uses an access token obtained with a OAuth 2 client ID. You cannot use an API key to retrieve private properties."
+        }
+      }
+    },
+    "PropertyList": {
+      "id": "PropertyList",
+      "type": "object",
+      "description": "A collection of properties, key-value pairs that are either public or private to an application.",
+      "properties": {
+        "etag": {
+          "type": "string",
+          "description": "The ETag of the list."
+        },
+        "items": {
+          "type": "array",
+          "description": "The list of properties.",
+          "items": {
+            "$ref": "Property"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "This is always drive#propertyList.",
+          "default": "drive#propertyList"
+        },
+        "selfLink": {
+          "type": "string",
+          "description": "The link back to this list."
+        }
+      }
+    },
+    "Revision": {
+      "id": "Revision",
+      "type": "object",
+      "description": "A revision of a file.",
+      "properties": {
+        "downloadUrl": {
+          "type": "string"
+        },
+        "etag": {
+          "type": "string",
+          "description": "The ETag of the revision."
+        },
+        "exportLinks": {
+          "type": "object",
+          "description": "Links for exporting Docs Editors files to specific formats.",
+          "additionalProperties": {
+            "type": "string",
+            "description": "A mapping from export format to URL"
+          }
+        },
+        "fileSize": {
+          "type": "string",
+          "description": "The size of the revision in bytes. This will only be populated on files with content stored in Drive.",
+          "format": "int64"
+        },
+        "id": {
+          "type": "string",
+          "description": "The ID of the revision."
+        },
+        "kind": {
+          "type": "string",
+          "description": "This is always drive#revision.",
+          "default": "drive#revision"
+        },
+        "lastModifyingUser": {
+          "$ref": "User",
+          "description": "The last user to modify this revision."
+        },
+        "lastModifyingUserName": {
+          "type": "string",
+          "description": "Name of the last user to modify this revision."
+        },
+        "md5Checksum": {
+          "type": "string",
+          "description": "An MD5 checksum for the content of this revision. This will only be populated on files with content stored in Drive."
+        },
+        "mimeType": {
+          "type": "string",
+          "description": "The MIME type of the revision."
+        },
+        "modifiedDate": {
+          "type": "string",
+          "description": "Last time this revision was modified (formatted RFC 3339 timestamp).",
+          "format": "date-time"
+        },
+        "originalFilename": {
+          "type": "string",
+          "description": "The original filename when this revision was created. This will only be populated on files with content stored in Drive."
+        },
+        "pinned": {
+          "type": "boolean",
+          "description": "Whether this revision is pinned to prevent automatic purging. If not set, the revision is automatically purged 30 days after newer content is uploaded. This field can only be modified on files with content stored in Drive, excluding Docs Editors files. Revisions can also be pinned when they are created through the drive.files.insert/update/copy by using the pinned query parameter. Pinned revisions are stored indefinitely using additional storage quota, up to a maximum of 200 revisions."
+        },
+        "publishAuto": {
+          "type": "boolean",
+          "description": "Whether subsequent revisions will be automatically republished. This is only populated and can only be modified for Docs Editors files."
+        },
+        "published": {
+          "type": "boolean",
+          "description": "Whether this revision is published. This is only populated and can only be modified for Docs Editors files."
+        },
+        "publishedLink": {
+          "type": "string",
+          "description": "A link to the published revision. This is only populated for Google Sites files."
+        },
+        "publishedOutsideDomain": {
+          "type": "boolean",
+          "description": "Whether this revision is published outside the domain. This is only populated and can only be modified for Docs Editors files."
+        },
+        "selfLink": {
+          "type": "string",
+          "description": "A link back to this revision."
+        }
+      }
+    },
+    "RevisionList": {
+      "id": "RevisionList",
+      "type": "object",
+      "description": "A list of revisions of a file.",
+      "properties": {
+        "etag": {
+          "type": "string",
+          "description": "The ETag of the list."
+        },
+        "items": {
+          "type": "array",
+          "description": "The list of revisions. If nextPageToken is populated, then this list may be incomplete and an additional page of results should be fetched.",
+          "items": {
+            "$ref": "Revision"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "This is always drive#revisionList.",
+          "default": "drive#revisionList"
+        },
+        "nextPageToken": {
+          "type": "string",
+          "description": "The page token for the next page of revisions. This field will be absent if the end of the revisions list has been reached. If the token is rejected for any reason, it should be discarded and pagination should be restarted from the first page of results."
+        },
+        "selfLink": {
+          "type": "string",
+          "description": "A link back to this list."
+        }
+      }
+    },
+    "StartPageToken": {
+      "id": "StartPageToken",
+      "type": "object",
+      "properties": {
+        "kind": {
+          "type": "string",
+          "description": "Identifies what kind of resource this is. Value: the fixed string \"drive#startPageToken\".",
+          "default": "drive#startPageToken"
+        },
+        "startPageToken": {
+          "type": "string",
+          "description": "The starting page token for listing changes."
+        }
+      }
+    },
+    "TeamDrive": {
+      "id": "TeamDrive",
+      "type": "object",
+      "description": "Deprecated: use the drive collection instead.",
+      "properties": {
+        "backgroundImageFile": {
+          "type": "object",
+          "description": "An image file and cropping parameters from which a background image for this Team Drive is set. This is a write only field; it can only be set on drive.teamdrives.update requests that don't set themeId. When specified, all fields of the backgroundImageFile must be set.",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of an image file in Drive to use for the background image."
+            },
+            "width": {
+              "type": "number",
+              "description": "The width of the cropped image in the closed range of 0 to 1. This value represents the width of the cropped image divided by the width of the entire image. The height is computed by applying a width to height aspect ratio of 80 to 9. The resulting image must be at least 1280 pixels wide and 144 pixels high.",
+              "format": "float"
+            },
+            "xCoordinate": {
+              "type": "number",
+              "description": "The X coordinate of the upper left corner of the cropping area in the background image. This is a value in the closed range of 0 to 1. This value represents the horizontal distance from the left side of the entire image to the left side of the cropping area divided by the width of the entire image.",
+              "format": "float"
+            },
+            "yCoordinate": {
+              "type": "number",
+              "description": "The Y coordinate of the upper left corner of the cropping area in the background image. This is a value in the closed range of 0 to 1. This value represents the vertical distance from the top side of the entire image to the top side of the cropping area divided by the height of the entire image.",
+              "format": "float"
+            }
+          }
+        },
+        "backgroundImageLink": {
+          "type": "string",
+          "description": "A short-lived link to this Team Drive's background image."
+        },
+        "capabilities": {
+          "type": "object",
+          "description": "Capabilities the current user has on this Team Drive.",
+          "properties": {
+            "canAddChildren": {
+              "type": "boolean",
+              "description": "Whether the current user can add children to folders in this Team Drive."
+            },
+            "canChangeCopyRequiresWriterPermissionRestriction": {
+              "type": "boolean",
+              "description": "Whether the current user can change the copyRequiresWriterPermission restriction of this Team Drive."
+            },
+            "canChangeDomainUsersOnlyRestriction": {
+              "type": "boolean",
+              "description": "Whether the current user can change the domainUsersOnly restriction of this Team Drive."
+            },
+            "canChangeTeamDriveBackground": {
+              "type": "boolean",
+              "description": "Whether the current user can change the background of this Team Drive."
+            },
+            "canChangeTeamMembersOnlyRestriction": {
+              "type": "boolean",
+              "description": "Whether the current user can change the teamMembersOnly restriction of this Team Drive."
+            },
+            "canComment": {
+              "type": "boolean",
+              "description": "Whether the current user can comment on files in this Team Drive."
+            },
+            "canCopy": {
+              "type": "boolean",
+              "description": "Whether the current user can copy files in this Team Drive."
+            },
+            "canDeleteChildren": {
+              "type": "boolean",
+              "description": "Whether the current user can delete children from folders in this Team Drive."
+            },
+            "canDeleteTeamDrive": {
+              "type": "boolean",
+              "description": "Whether the current user can delete this Team Drive. Attempting to delete the Team Drive may still fail if there are untrashed items inside the Team Drive."
+            },
+            "canDownload": {
+              "type": "boolean",
+              "description": "Whether the current user can download files in this Team Drive."
+            },
+            "canEdit": {
+              "type": "boolean",
+              "description": "Whether the current user can edit files in this Team Drive"
+            },
+            "canListChildren": {
+              "type": "boolean",
+              "description": "Whether the current user can list the children of folders in this Team Drive."
+            },
+            "canManageMembers": {
+              "type": "boolean",
+              "description": "Whether the current user can add members to this Team Drive or remove them or change their role."
+            },
+            "canReadRevisions": {
+              "type": "boolean",
+              "description": "Whether the current user can read the revisions resource of files in this Team Drive."
+            },
+            "canRemoveChildren": {
+              "type": "boolean",
+              "description": "Deprecated - use canDeleteChildren or canTrashChildren instead."
+            },
+            "canRename": {
+              "type": "boolean",
+              "description": "Whether the current user can rename files or folders in this Team Drive."
+            },
+            "canRenameTeamDrive": {
+              "type": "boolean",
+              "description": "Whether the current user can rename this Team Drive."
+            },
+            "canResetTeamDriveRestrictions": {
+              "type": "boolean",
+              "description": "Whether the current user can reset the Team Drive restrictions to defaults."
+            },
+            "canShare": {
+              "type": "boolean",
+              "description": "Whether the current user can share files or folders in this Team Drive."
+            },
+            "canTrashChildren": {
+              "type": "boolean",
+              "description": "Whether the current user can trash children from folders in this Team Drive."
+            }
+          }
+        },
+        "colorRgb": {
+          "type": "string",
+          "description": "The color of this Team Drive as an RGB hex string. It can only be set on a drive.teamdrives.update request that does not set themeId."
+        },
+        "createdDate": {
+          "type": "string",
+          "description": "The time at which the Team Drive was created (RFC 3339 date-time).",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string",
+          "description": "The ID of this Team Drive which is also the ID of the top level folder of this Team Drive."
+        },
+        "kind": {
+          "type": "string",
+          "description": "This is always drive#teamDrive",
+          "default": "drive#teamDrive"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of this Team Drive.",
+          "annotations": {
+            "required": [
+              "drive.teamdrives.insert"
+            ]
+          }
+        },
+        "orgUnitId": {
+          "type": "string",
+          "description": "The organizational unit of this shared drive. This field is only populated on drives.list responses when the useDomainAdminAccess parameter is set to true."
+        },
+        "restrictions": {
+          "type": "object",
+          "description": "A set of restrictions that apply to this Team Drive or items inside this Team Drive.",
+          "properties": {
+            "adminManagedRestrictions": {
+              "type": "boolean",
+              "description": "Whether administrative privileges on this Team Drive are required to modify restrictions."
+            },
+            "copyRequiresWriterPermission": {
+              "type": "boolean",
+              "description": "Whether the options to copy, print, or download files inside this Team Drive, should be disabled for readers and commenters. When this restriction is set to true, it will override the similarly named field to true for any file inside this Team Drive."
+            },
+            "domainUsersOnly": {
+              "type": "boolean",
+              "description": "Whether access to this Team Drive and items inside this Team Drive is restricted to users of the domain to which this Team Drive belongs. This restriction may be overridden by other sharing policies controlled outside of this Team Drive."
+            },
+            "teamMembersOnly": {
+              "type": "boolean",
+              "description": "Whether access to items inside this Team Drive is restricted to members of this Team Drive."
+            }
+          }
+        },
+        "themeId": {
+          "type": "string",
+          "description": "The ID of the theme from which the background image and color will be set. The set of possible teamDriveThemes can be retrieved from a drive.about.get response. When not specified on a drive.teamdrives.insert request, a random theme is chosen from which the background image and color are set. This is a write-only field; it can only be set on requests that don't set colorRgb or backgroundImageFile."
+        }
+      }
+    },
+    "TeamDriveList": {
+      "id": "TeamDriveList",
+      "type": "object",
+      "description": "A list of Team Drives.",
+      "properties": {
+        "items": {
+          "type": "array",
+          "description": "The list of Team Drives.",
+          "items": {
+            "$ref": "TeamDrive"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "This is always drive#teamDriveList",
+          "default": "drive#teamDriveList"
+        },
+        "nextPageToken": {
+          "type": "string",
+          "description": "The page token for the next page of Team Drives."
+        }
+      }
+    },
+    "User": {
+      "id": "User",
+      "type": "object",
+      "description": "Information about a Drive user.",
+      "properties": {
+        "displayName": {
+          "type": "string",
+          "description": "A plain text displayable name for this user."
+        },
+        "emailAddress": {
+          "type": "string",
+          "description": "The email address of the user."
+        },
+        "isAuthenticatedUser": {
+          "type": "boolean",
+          "description": "Whether this user is the same as the authenticated user for whom the request was made."
+        },
+        "kind": {
+          "type": "string",
+          "description": "This is always drive#user.",
+          "default": "drive#user"
+        },
+        "permissionId": {
+          "type": "string",
+          "description": "The user's ID as visible in the permissions collection."
+        },
+        "picture": {
+          "type": "object",
+          "description": "The user's profile picture.",
+          "properties": {
+            "url": {
+              "type": "string",
+              "description": "A URL that points to a profile picture of this user."
+            }
+          }
+        }
+      }
+    }
+  },
+  "resources": {
+    "about": {
+      "methods": {
+        "get": {
+          "id": "drive.about.get",
+          "path": "about",
+          "httpMethod": "GET",
+          "description": "Gets the information about the current user along with Drive API settings",
+          "parameters": {
+            "includeSubscribed": {
+              "type": "boolean",
+              "description": "Whether to count changes outside the My Drive hierarchy. When set to false, changes to files such as those in the Application Data folder or shared files which have not been added to My Drive will be omitted from the maxChangeIdCount.",
+              "default": "true",
+              "location": "query"
+            },
+            "maxChangeIdCount": {
+              "type": "string",
+              "description": "Maximum number of remaining change IDs to count",
+              "default": "1",
+              "format": "int64",
+              "location": "query"
+            },
+            "startChangeId": {
+              "type": "string",
+              "description": "Change ID to start counting from when calculating number of remaining change IDs",
+              "format": "int64",
+              "location": "query"
+            }
+          },
+          "response": {
+            "$ref": "About"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.appdata",
+            "https://www.googleapis.com/auth/drive.file",
+            "https://www.googleapis.com/auth/drive.metadata",
+            "https://www.googleapis.com/auth/drive.metadata.readonly",
+            "https://www.googleapis.com/auth/drive.photos.readonly",
+            "https://www.googleapis.com/auth/drive.readonly"
+          ]
+        }
+      }
+    },
+    "apps": {
+      "methods": {
+        "get": {
+          "id": "drive.apps.get",
+          "path": "apps/{appId}",
+          "httpMethod": "GET",
+          "description": "Gets a specific app.",
+          "parameters": {
+            "appId": {
+              "type": "string",
+              "description": "The ID of the app.",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "parameterOrder": [
+            "appId"
+          ],
+          "response": {
+            "$ref": "App"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.appdata",
+            "https://www.googleapis.com/auth/drive.apps.readonly",
+            "https://www.googleapis.com/auth/drive.file",
+            "https://www.googleapis.com/auth/drive.metadata",
+            "https://www.googleapis.com/auth/drive.metadata.readonly",
+            "https://www.googleapis.com/auth/drive.readonly"
+          ]
+        },
+        "list": {
+          "id": "drive.apps.list",
+          "path": "apps",
+          "httpMethod": "GET",
+          "description": "Lists a user's installed apps.",
+          "parameters": {
+            "appFilterExtensions": {
+              "type": "string",
+              "description": "A comma-separated list of file extensions for open with filtering. All apps within the given app query scope which can open any of the given file extensions will be included in the response. If appFilterMimeTypes are provided as well, the result is a union of the two resulting app lists.",
+              "default": "",
+              "location": "query"
+            },
+            "appFilterMimeTypes": {
+              "type": "string",
+              "description": "A comma-separated list of MIME types for open with filtering. All apps within the given app query scope which can open any of the given MIME types will be included in the response. If appFilterExtensions are provided as well, the result is a union of the two resulting app lists.",
+              "default": "",
+              "location": "query"
+            },
+            "languageCode": {
+              "type": "string",
+              "description": "A language or locale code, as defined by BCP 47, with some extensions from Unicode's LDML format (http://www.unicode.org/reports/tr35/).",
+              "location": "query"
+            }
+          },
+          "response": {
+            "$ref": "AppList"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive.apps.readonly"
+          ]
+        }
+      }
+    },
+    "changes": {
+      "methods": {
+        "get": {
+          "id": "drive.changes.get",
+          "path": "changes/{changeId}",
+          "httpMethod": "GET",
+          "description": "Deprecated - Use changes.getStartPageToken and changes.list to retrieve recent changes.",
+          "parameters": {
+            "changeId": {
+              "type": "string",
+              "description": "The ID of the change.",
+              "required": true,
+              "location": "path"
+            },
+            "driveId": {
+              "type": "string",
+              "description": "The shared drive from which the change is returned.",
+              "location": "query"
+            },
+            "supportsAllDrives": {
+              "type": "boolean",
+              "description": "Whether the requesting application supports both My Drives and shared drives.",
+              "default": "false",
+              "location": "query"
+            },
+            "supportsTeamDrives": {
+              "type": "boolean",
+              "description": "Deprecated use supportsAllDrives instead.",
+              "default": "false",
+              "location": "query"
+            },
+            "teamDriveId": {
+              "type": "string",
+              "description": "Deprecated use driveId instead.",
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "changeId"
+          ],
+          "response": {
+            "$ref": "Change"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.appdata",
+            "https://www.googleapis.com/auth/drive.apps.readonly",
+            "https://www.googleapis.com/auth/drive.file",
+            "https://www.googleapis.com/auth/drive.metadata",
+            "https://www.googleapis.com/auth/drive.metadata.readonly",
+            "https://www.googleapis.com/auth/drive.photos.readonly",
+            "https://www.googleapis.com/auth/drive.readonly"
+          ]
+        },
+        "getStartPageToken": {
+          "id": "drive.changes.getStartPageToken",
+          "path": "changes/startPageToken",
+          "httpMethod": "GET",
+          "description": "Gets the starting pageToken for listing future changes.",
+          "parameters": {
+            "driveId": {
+              "type": "string",
+              "description": "The ID of the shared drive for which the starting pageToken for listing future changes from that shared drive is returned.",
+              "location": "query"
+            },
+            "supportsAllDrives": {
+              "type": "boolean",
+              "description": "Whether the requesting application supports both My Drives and shared drives.",
+              "default": "false",
+              "location": "query"
+            },
+            "supportsTeamDrives": {
+              "type": "boolean",
+              "description": "Deprecated use supportsAllDrives instead.",
+              "default": "false",
+              "location": "query"
+            },
+            "teamDriveId": {
+              "type": "string",
+              "description": "Deprecated use driveId instead.",
+              "location": "query"
+            }
+          },
+          "response": {
+            "$ref": "StartPageToken"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.appdata",
+            "https://www.googleapis.com/auth/drive.apps.readonly",
+            "https://www.googleapis.com/auth/drive.file",
+            "https://www.googleapis.com/auth/drive.metadata",
+            "https://www.googleapis.com/auth/drive.metadata.readonly",
+            "https://www.googleapis.com/auth/drive.photos.readonly",
+            "https://www.googleapis.com/auth/drive.readonly"
+          ]
+        },
+        "list": {
+          "id": "drive.changes.list",
+          "path": "changes",
+          "httpMethod": "GET",
+          "description": "Lists the changes for a user or shared drive.",
+          "parameters": {
+            "driveId": {
+              "type": "string",
+              "description": "The shared drive from which changes are returned. If specified the change IDs will be reflective of the shared drive; use the combined drive ID and change ID as an identifier.",
+              "location": "query"
+            },
+            "includeCorpusRemovals": {
+              "type": "boolean",
+              "description": "Whether changes should include the file resource if the file is still accessible by the user at the time of the request, even when a file was removed from the list of changes and there will be no further change entries for this file.",
+              "default": "false",
+              "location": "query"
+            },
+            "includeDeleted": {
+              "type": "boolean",
+              "description": "Whether to include changes indicating that items have been removed from the list of changes, for example by deletion or loss of access.",
+              "default": "true",
+              "location": "query"
+            },
+            "includeItemsFromAllDrives": {
+              "type": "boolean",
+              "description": "Whether both My Drive and shared drive items should be included in results.",
+              "default": "false",
+              "location": "query"
+            },
+            "includePermissionsForView": {
+              "type": "string",
+              "description": "Specifies which additional view's permissions to include in the response. Only 'published' is supported.",
+              "location": "query"
+            },
+            "includeSubscribed": {
+              "type": "boolean",
+              "description": "Whether to include changes outside the My Drive hierarchy in the result. When set to false, changes to files such as those in the Application Data folder or shared files which have not been added to My Drive are omitted from the result.",
+              "default": "true",
+              "location": "query"
+            },
+            "includeTeamDriveItems": {
+              "type": "boolean",
+              "description": "Deprecated use includeItemsFromAllDrives instead.",
+              "default": "false",
+              "location": "query"
+            },
+            "maxResults": {
+              "type": "integer",
+              "description": "Maximum number of changes to return.",
+              "default": "100",
+              "format": "int32",
+              "minimum": "1",
+              "location": "query"
+            },
+            "pageToken": {
+              "type": "string",
+              "description": "The token for continuing a previous list request on the next page. This should be set to the value of 'nextPageToken' from the previous response or to the response from the getStartPageToken method.",
+              "location": "query"
+            },
+            "spaces": {
+              "type": "string",
+              "description": "A comma-separated list of spaces to query. Supported values are 'drive', 'appDataFolder' and 'photos'.",
+              "location": "query"
+            },
+            "startChangeId": {
+              "type": "string",
+              "description": "Deprecated - use pageToken instead.",
+              "format": "int64",
+              "location": "query"
+            },
+            "supportsAllDrives": {
+              "type": "boolean",
+              "description": "Whether the requesting application supports both My Drives and shared drives.",
+              "default": "false",
+              "location": "query"
+            },
+            "supportsTeamDrives": {
+              "type": "boolean",
+              "description": "Deprecated use supportsAllDrives instead.",
+              "default": "false",
+              "location": "query"
+            },
+            "teamDriveId": {
+              "type": "string",
+              "description": "Deprecated use driveId instead.",
+              "location": "query"
+            }
+          },
+          "response": {
+            "$ref": "ChangeList"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.appdata",
+            "https://www.googleapis.com/auth/drive.apps.readonly",
+            "https://www.googleapis.com/auth/drive.file",
+            "https://www.googleapis.com/auth/drive.metadata",
+            "https://www.googleapis.com/auth/drive.metadata.readonly",
+            "https://www.googleapis.com/auth/drive.photos.readonly",
+            "https://www.googleapis.com/auth/drive.readonly"
+          ],
+          "supportsSubscription": true
+        },
+        "watch": {
+          "id": "drive.changes.watch",
+          "path": "changes/watch",
+          "httpMethod": "POST",
+          "description": "Subscribe to changes for a user.",
+          "parameters": {
+            "driveId": {
+              "type": "string",
+              "description": "The shared drive from which changes are returned. If specified the change IDs will be reflective of the shared drive; use the combined drive ID and change ID as an identifier.",
+              "location": "query"
+            },
+            "includeCorpusRemovals": {
+              "type": "boolean",
+              "description": "Whether changes should include the file resource if the file is still accessible by the user at the time of the request, even when a file was removed from the list of changes and there will be no further change entries for this file.",
+              "default": "false",
+              "location": "query"
+            },
+            "includeDeleted": {
+              "type": "boolean",
+              "description": "Whether to include changes indicating that items have been removed from the list of changes, for example by deletion or loss of access.",
+              "default": "true",
+              "location": "query"
+            },
+            "includeItemsFromAllDrives": {
+              "type": "boolean",
+              "description": "Whether both My Drive and shared drive items should be included in results.",
+              "default": "false",
+              "location": "query"
+            },
+            "includePermissionsForView": {
+              "type": "string",
+              "description": "Specifies which additional view's permissions to include in the response. Only 'published' is supported.",
+              "location": "query"
+            },
+            "includeSubscribed": {
+              "type": "boolean",
+              "description": "Whether to include changes outside the My Drive hierarchy in the result. When set to false, changes to files such as those in the Application Data folder or shared files which have not been added to My Drive are omitted from the result.",
+              "default": "true",
+              "location": "query"
+            },
+            "includeTeamDriveItems": {
+              "type": "boolean",
+              "description": "Deprecated use includeItemsFromAllDrives instead.",
+              "default": "false",
+              "location": "query"
+            },
+            "maxResults": {
+              "type": "integer",
+              "description": "Maximum number of changes to return.",
+              "default": "100",
+              "format": "int32",
+              "minimum": "1",
+              "location": "query"
+            },
+            "pageToken": {
+              "type": "string",
+              "description": "The token for continuing a previous list request on the next page. This should be set to the value of 'nextPageToken' from the previous response or to the response from the getStartPageToken method.",
+              "location": "query"
+            },
+            "spaces": {
+              "type": "string",
+              "description": "A comma-separated list of spaces to query. Supported values are 'drive', 'appDataFolder' and 'photos'.",
+              "location": "query"
+            },
+            "startChangeId": {
+              "type": "string",
+              "description": "Deprecated - use pageToken instead.",
+              "format": "int64",
+              "location": "query"
+            },
+            "supportsAllDrives": {
+              "type": "boolean",
+              "description": "Whether the requesting application supports both My Drives and shared drives.",
+              "default": "false",
+              "location": "query"
+            },
+            "supportsTeamDrives": {
+              "type": "boolean",
+              "description": "Deprecated use supportsAllDrives instead.",
+              "default": "false",
+              "location": "query"
+            },
+            "teamDriveId": {
+              "type": "string",
+              "description": "Deprecated use driveId instead.",
+              "location": "query"
+            }
+          },
+          "request": {
+            "$ref": "Channel",
+            "parameterName": "resource"
+          },
+          "response": {
+            "$ref": "Channel"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.appdata",
+            "https://www.googleapis.com/auth/drive.apps.readonly",
+            "https://www.googleapis.com/auth/drive.file",
+            "https://www.googleapis.com/auth/drive.metadata",
+            "https://www.googleapis.com/auth/drive.metadata.readonly",
+            "https://www.googleapis.com/auth/drive.photos.readonly",
+            "https://www.googleapis.com/auth/drive.readonly"
+          ],
+          "supportsSubscription": true
+        }
+      }
+    },
+    "channels": {
+      "methods": {
+        "stop": {
+          "id": "drive.channels.stop",
+          "path": "channels/stop",
+          "httpMethod": "POST",
+          "description": "Stop watching resources through this channel",
+          "request": {
+            "$ref": "Channel",
+            "parameterName": "resource"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.appdata",
+            "https://www.googleapis.com/auth/drive.apps.readonly",
+            "https://www.googleapis.com/auth/drive.file",
+            "https://www.googleapis.com/auth/drive.metadata",
+            "https://www.googleapis.com/auth/drive.metadata.readonly",
+            "https://www.googleapis.com/auth/drive.photos.readonly",
+            "https://www.googleapis.com/auth/drive.readonly"
+          ]
+        }
+      }
+    },
+    "children": {
+      "methods": {
+        "delete": {
+          "id": "drive.children.delete",
+          "path": "files/{folderId}/children/{childId}",
+          "httpMethod": "DELETE",
+          "description": "Removes a child from a folder.",
+          "parameters": {
+            "childId": {
+              "type": "string",
+              "description": "The ID of the child.",
+              "required": true,
+              "location": "path"
+            },
+            "enforceSingleParent": {
+              "type": "boolean",
+              "description": "Deprecated. If an item is not in a shared drive and its last parent is deleted but the item itself is not, the item will be placed under its owner's root.",
+              "default": "false",
+              "location": "query"
+            },
+            "folderId": {
+              "type": "string",
+              "description": "The ID of the folder.",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "parameterOrder": [
+            "folderId",
+            "childId"
+          ],
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.file"
+          ]
+        },
+        "get": {
+          "id": "drive.children.get",
+          "path": "files/{folderId}/children/{childId}",
+          "httpMethod": "GET",
+          "description": "Gets a specific child reference.",
+          "parameters": {
+            "childId": {
+              "type": "string",
+              "description": "The ID of the child.",
+              "required": true,
+              "location": "path"
+            },
+            "folderId": {
+              "type": "string",
+              "description": "The ID of the folder.",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "parameterOrder": [
+            "folderId",
+            "childId"
+          ],
+          "response": {
+            "$ref": "ChildReference"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.appdata",
+            "https://www.googleapis.com/auth/drive.file",
+            "https://www.googleapis.com/auth/drive.metadata",
+            "https://www.googleapis.com/auth/drive.metadata.readonly",
+            "https://www.googleapis.com/auth/drive.photos.readonly",
+            "https://www.googleapis.com/auth/drive.readonly"
+          ]
+        },
+        "insert": {
+          "id": "drive.children.insert",
+          "path": "files/{folderId}/children",
+          "httpMethod": "POST",
+          "description": "Inserts a file into a folder.",
+          "parameters": {
+            "enforceSingleParent": {
+              "type": "boolean",
+              "description": "Deprecated. Adding files to multiple folders is no longer supported. Use shortcuts instead.",
+              "default": "false",
+              "location": "query"
+            },
+            "folderId": {
+              "type": "string",
+              "description": "The ID of the folder.",
+              "required": true,
+              "location": "path"
+            },
+            "supportsAllDrives": {
+              "type": "boolean",
+              "description": "Whether the requesting application supports both My Drives and shared drives.",
+              "default": "false",
+              "location": "query"
+            },
+            "supportsTeamDrives": {
+              "type": "boolean",
+              "description": "Deprecated use supportsAllDrives instead.",
+              "default": "false",
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "folderId"
+          ],
+          "request": {
+            "$ref": "ChildReference"
+          },
+          "response": {
+            "$ref": "ChildReference"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.appdata",
+            "https://www.googleapis.com/auth/drive.file"
+          ]
+        },
+        "list": {
+          "id": "drive.children.list",
+          "path": "files/{folderId}/children",
+          "httpMethod": "GET",
+          "description": "Lists a folder's children.",
+          "parameters": {
+            "folderId": {
+              "type": "string",
+              "description": "The ID of the folder.",
+              "required": true,
+              "location": "path"
+            },
+            "maxResults": {
+              "type": "integer",
+              "description": "Maximum number of children to return.",
+              "default": "100",
+              "format": "int32",
+              "minimum": "0",
+              "location": "query"
+            },
+            "orderBy": {
+              "type": "string",
+              "description": "A comma-separated list of sort keys. Valid keys are 'createdDate', 'folder', 'lastViewedByMeDate', 'modifiedByMeDate', 'modifiedDate', 'quotaBytesUsed', 'recency', 'sharedWithMeDate', 'starred', and 'title'. Each key sorts ascending by default, but may be reversed with the 'desc' modifier. Example usage: ?orderBy=folder,modifiedDate desc,title. Please note that there is a current limitation for users with approximately one million files in which the requested sort order is ignored.",
+              "location": "query"
+            },
+            "pageToken": {
+              "type": "string",
+              "description": "Page token for children.",
+              "location": "query"
+            },
+            "q": {
+              "type": "string",
+              "description": "Query string for searching children.",
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "folderId"
+          ],
+          "response": {
+            "$ref": "ChildList"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.appdata",
+            "https://www.googleapis.com/auth/drive.file",
+            "https://www.googleapis.com/auth/drive.metadata",
+            "https://www.googleapis.com/auth/drive.metadata.readonly",
+            "https://www.googleapis.com/auth/drive.photos.readonly",
+            "https://www.googleapis.com/auth/drive.readonly"
+          ]
+        }
+      }
+    },
+    "comments": {
+      "methods": {
+        "delete": {
+          "id": "drive.comments.delete",
+          "path": "files/{fileId}/comments/{commentId}",
+          "httpMethod": "DELETE",
+          "description": "Deletes a comment.",
+          "parameters": {
+            "commentId": {
+              "type": "string",
+              "description": "The ID of the comment.",
+              "required": true,
+              "location": "path"
+            },
+            "fileId": {
+              "type": "string",
+              "description": "The ID of the file.",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "parameterOrder": [
+            "fileId",
+            "commentId"
+          ],
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.file"
+          ]
+        },
+        "get": {
+          "id": "drive.comments.get",
+          "path": "files/{fileId}/comments/{commentId}",
+          "httpMethod": "GET",
+          "description": "Gets a comment by ID.",
+          "parameters": {
+            "commentId": {
+              "type": "string",
+              "description": "The ID of the comment.",
+              "required": true,
+              "location": "path"
+            },
+            "fileId": {
+              "type": "string",
+              "description": "The ID of the file.",
+              "required": true,
+              "location": "path"
+            },
+            "includeDeleted": {
+              "type": "boolean",
+              "description": "If set, this will succeed when retrieving a deleted comment, and will include any deleted replies.",
+              "default": "false",
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "fileId",
+            "commentId"
+          ],
+          "response": {
+            "$ref": "Comment"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.file",
+            "https://www.googleapis.com/auth/drive.readonly"
+          ]
+        },
+        "insert": {
+          "id": "drive.comments.insert",
+          "path": "files/{fileId}/comments",
+          "httpMethod": "POST",
+          "description": "Creates a new comment on the given file.",
+          "parameters": {
+            "fileId": {
+              "type": "string",
+              "description": "The ID of the file.",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "parameterOrder": [
+            "fileId"
+          ],
+          "request": {
+            "$ref": "Comment"
+          },
+          "response": {
+            "$ref": "Comment"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.file"
+          ]
+        },
+        "list": {
+          "id": "drive.comments.list",
+          "path": "files/{fileId}/comments",
+          "httpMethod": "GET",
+          "description": "Lists a file's comments.",
+          "parameters": {
+            "fileId": {
+              "type": "string",
+              "description": "The ID of the file.",
+              "required": true,
+              "location": "path"
+            },
+            "includeDeleted": {
+              "type": "boolean",
+              "description": "If set, all comments and replies, including deleted comments and replies (with content stripped) will be returned.",
+              "default": "false",
+              "location": "query"
+            },
+            "maxResults": {
+              "type": "integer",
+              "description": "The maximum number of discussions to include in the response, used for paging.",
+              "default": "20",
+              "format": "int32",
+              "minimum": "0",
+              "maximum": "100",
+              "location": "query"
+            },
+            "pageToken": {
+              "type": "string",
+              "description": "The continuation token, used to page through large result sets. To get the next page of results, set this parameter to the value of \"nextPageToken\" from the previous response.",
+              "location": "query"
+            },
+            "updatedMin": {
+              "type": "string",
+              "description": "Only discussions that were updated after this timestamp will be returned. Formatted as an RFC 3339 timestamp.",
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "fileId"
+          ],
+          "response": {
+            "$ref": "CommentList"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.file",
+            "https://www.googleapis.com/auth/drive.readonly"
+          ]
+        },
+        "patch": {
+          "id": "drive.comments.patch",
+          "path": "files/{fileId}/comments/{commentId}",
+          "httpMethod": "PATCH",
+          "description": "Updates an existing comment.",
+          "parameters": {
+            "commentId": {
+              "type": "string",
+              "description": "The ID of the comment.",
+              "required": true,
+              "location": "path"
+            },
+            "fileId": {
+              "type": "string",
+              "description": "The ID of the file.",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "parameterOrder": [
+            "fileId",
+            "commentId"
+          ],
+          "request": {
+            "$ref": "Comment"
+          },
+          "response": {
+            "$ref": "Comment"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.file"
+          ]
+        },
+        "update": {
+          "id": "drive.comments.update",
+          "path": "files/{fileId}/comments/{commentId}",
+          "httpMethod": "PUT",
+          "description": "Updates an existing comment.",
+          "parameters": {
+            "commentId": {
+              "type": "string",
+              "description": "The ID of the comment.",
+              "required": true,
+              "location": "path"
+            },
+            "fileId": {
+              "type": "string",
+              "description": "The ID of the file.",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "parameterOrder": [
+            "fileId",
+            "commentId"
+          ],
+          "request": {
+            "$ref": "Comment"
+          },
+          "response": {
+            "$ref": "Comment"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.file"
+          ]
+        }
+      }
+    },
+    "drives": {
+      "methods": {
+        "delete": {
+          "id": "drive.drives.delete",
+          "path": "drives/{driveId}",
+          "httpMethod": "DELETE",
+          "description": "Permanently deletes a shared drive for which the user is an organizer. The shared drive cannot contain any untrashed items.",
+          "parameters": {
+            "allowItemDeletion": {
+              "type": "boolean",
+              "description": "Whether any items inside the shared drive should also be deleted. This option is only supported when useDomainAdminAccess is also set to true.",
+              "default": "false",
+              "location": "query"
+            },
+            "driveId": {
+              "type": "string",
+              "description": "The ID of the shared drive.",
+              "required": true,
+              "location": "path"
+            },
+            "useDomainAdminAccess": {
+              "type": "boolean",
+              "description": "Issue the request as a domain administrator; if set to true, then the requester will be granted access if they are an administrator of the domain to which the shared drive belongs.",
+              "default": "false",
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "driveId"
+          ],
+          "scopes": [
+            "https://www.googleapis.com/auth/drive"
+          ]
+        },
+        "get": {
+          "id": "drive.drives.get",
+          "path": "drives/{driveId}",
+          "httpMethod": "GET",
+          "description": "Gets a shared drive's metadata by ID.",
+          "parameters": {
+            "driveId": {
+              "type": "string",
+              "description": "The ID of the shared drive.",
+              "required": true,
+              "location": "path"
+            },
+            "useDomainAdminAccess": {
+              "type": "boolean",
+              "description": "Issue the request as a domain administrator; if set to true, then the requester will be granted access if they are an administrator of the domain to which the shared drive belongs.",
+              "default": "false",
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "driveId"
+          ],
+          "response": {
+            "$ref": "Drive"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.readonly"
+          ]
+        },
+        "hide": {
+          "id": "drive.drives.hide",
+          "path": "drives/{driveId}/hide",
+          "httpMethod": "POST",
+          "description": "Hides a shared drive from the default view.",
+          "parameters": {
+            "driveId": {
+              "type": "string",
+              "description": "The ID of the shared drive.",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "parameterOrder": [
+            "driveId"
+          ],
+          "response": {
+            "$ref": "Drive"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive"
+          ]
+        },
+        "insert": {
+          "id": "drive.drives.insert",
+          "path": "drives",
+          "httpMethod": "POST",
+          "description": "Creates a new shared drive.",
+          "parameters": {
+            "requestId": {
+              "type": "string",
+              "description": "An ID, such as a random UUID, which uniquely identifies this user's request for idempotent creation of a shared drive. A repeated request by the same user and with the same request ID will avoid creating duplicates by attempting to create the same shared drive. If the shared drive already exists a 409 error will be returned.",
+              "required": true,
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "requestId"
+          ],
+          "request": {
+            "$ref": "Drive"
+          },
+          "response": {
+            "$ref": "Drive"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive"
+          ]
+        },
+        "list": {
+          "id": "drive.drives.list",
+          "path": "drives",
+          "httpMethod": "GET",
+          "description": "Lists the user's shared drives.",
+          "parameters": {
+            "maxResults": {
+              "type": "integer",
+              "description": "Maximum number of shared drives to return per page.",
+              "default": "10",
+              "format": "int32",
+              "minimum": "1",
+              "maximum": "100",
+              "location": "query"
+            },
+            "pageToken": {
+              "type": "string",
+              "description": "Page token for shared drives.",
+              "location": "query"
+            },
+            "q": {
+              "type": "string",
+              "description": "Query string for searching shared drives.",
+              "location": "query"
+            },
+            "useDomainAdminAccess": {
+              "type": "boolean",
+              "description": "Issue the request as a domain administrator; if set to true, then all shared drives of the domain in which the requester is an administrator are returned.",
+              "default": "false",
+              "location": "query"
+            }
+          },
+          "response": {
+            "$ref": "DriveList"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.readonly"
+          ]
+        },
+        "unhide": {
+          "id": "drive.drives.unhide",
+          "path": "drives/{driveId}/unhide",
+          "httpMethod": "POST",
+          "description": "Restores a shared drive to the default view.",
+          "parameters": {
+            "driveId": {
+              "type": "string",
+              "description": "The ID of the shared drive.",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "parameterOrder": [
+            "driveId"
+          ],
+          "response": {
+            "$ref": "Drive"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive"
+          ]
+        },
+        "update": {
+          "id": "drive.drives.update",
+          "path": "drives/{driveId}",
+          "httpMethod": "PUT",
+          "description": "Updates the metadata for a shared drive.",
+          "parameters": {
+            "driveId": {
+              "type": "string",
+              "description": "The ID of the shared drive.",
+              "required": true,
+              "location": "path"
+            },
+            "useDomainAdminAccess": {
+              "type": "boolean",
+              "description": "Issue the request as a domain administrator; if set to true, then the requester will be granted access if they are an administrator of the domain to which the shared drive belongs.",
+              "default": "false",
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "driveId"
+          ],
+          "request": {
+            "$ref": "Drive"
+          },
+          "response": {
+            "$ref": "Drive"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive"
+          ]
+        }
+      }
+    },
+    "files": {
+      "methods": {
+        "copy": {
+          "id": "drive.files.copy",
+          "path": "files/{fileId}/copy",
+          "httpMethod": "POST",
+          "description": "Creates a copy of the specified file. Folders cannot be copied.",
+          "parameters": {
+            "convert": {
+              "type": "boolean",
+              "description": "Whether to convert this file to the corresponding Docs Editors format.",
+              "default": "false",
+              "location": "query"
+            },
+            "enforceSingleParent": {
+              "type": "boolean",
+              "description": "Deprecated. Copying files into multiple folders is no longer supported. Use shortcuts instead.",
+              "default": "false",
+              "location": "query"
+            },
+            "fileId": {
+              "type": "string",
+              "description": "The ID of the file to copy.",
+              "required": true,
+              "location": "path"
+            },
+            "includePermissionsForView": {
+              "type": "string",
+              "description": "Specifies which additional view's permissions to include in the response. Only 'published' is supported.",
+              "location": "query"
+            },
+            "ocr": {
+              "type": "boolean",
+              "description": "Whether to attempt OCR on .jpg, .png, .gif, or .pdf uploads.",
+              "default": "false",
+              "location": "query"
+            },
+            "ocrLanguage": {
+              "type": "string",
+              "description": "If ocr is true, hints at the language to use. Valid values are BCP 47 codes.",
+              "location": "query"
+            },
+            "pinned": {
+              "type": "boolean",
+              "description": "Whether to pin the head revision of the new copy. A file can have a maximum of 200 pinned revisions.",
+              "default": "false",
+              "location": "query"
+            },
+            "supportsAllDrives": {
+              "type": "boolean",
+              "description": "Whether the requesting application supports both My Drives and shared drives.",
+              "default": "false",
+              "location": "query"
+            },
+            "supportsTeamDrives": {
+              "type": "boolean",
+              "description": "Deprecated use supportsAllDrives instead.",
+              "default": "false",
+              "location": "query"
+            },
+            "timedTextLanguage": {
+              "type": "string",
+              "description": "The language of the timed text.",
+              "location": "query"
+            },
+            "timedTextTrackName": {
+              "type": "string",
+              "description": "The timed text track name.",
+              "location": "query"
+            },
+            "visibility": {
+              "type": "string",
+              "description": "The visibility of the new file. This parameter is only relevant when the source is not a native Google Doc and convert=false.",
+              "default": "DEFAULT",
+              "enum": [
+                "DEFAULT",
+                "PRIVATE"
+              ],
+              "enumDescriptions": [
+                "The visibility of the new file is determined by the user's default visibility/sharing policies.",
+                "The new file will be visible to only the owner."
+              ],
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "fileId"
+          ],
+          "request": {
+            "$ref": "File"
+          },
+          "response": {
+            "$ref": "File"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.appdata",
+            "https://www.googleapis.com/auth/drive.apps.readonly",
+            "https://www.googleapis.com/auth/drive.file",
+            "https://www.googleapis.com/auth/drive.photos.readonly"
+          ]
+        },
+        "delete": {
+          "id": "drive.files.delete",
+          "path": "files/{fileId}",
+          "httpMethod": "DELETE",
+          "description": "Permanently deletes a file by ID. Skips the trash. The currently authenticated user must own the file or be an organizer on the parent for shared drive files.",
+          "parameters": {
+            "enforceSingleParent": {
+              "type": "boolean",
+              "description": "Deprecated. If an item is not in a shared drive and its last parent is deleted but the item itself is not, the item will be placed under its owner's root.",
+              "default": "false",
+              "location": "query"
+            },
+            "fileId": {
+              "type": "string",
+              "description": "The ID of the file to delete.",
+              "required": true,
+              "location": "path"
+            },
+            "supportsAllDrives": {
+              "type": "boolean",
+              "description": "Whether the requesting application supports both My Drives and shared drives.",
+              "default": "false",
+              "location": "query"
+            },
+            "supportsTeamDrives": {
+              "type": "boolean",
+              "description": "Deprecated use supportsAllDrives instead.",
+              "default": "false",
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "fileId"
+          ],
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.appdata",
+            "https://www.googleapis.com/auth/drive.file"
+          ]
+        },
+        "emptyTrash": {
+          "id": "drive.files.emptyTrash",
+          "path": "files/trash",
+          "httpMethod": "DELETE",
+          "description": "Permanently deletes all of the user's trashed files.",
+          "parameters": {
+            "enforceSingleParent": {
+              "type": "boolean",
+              "description": "Deprecated. If an item is not in a shared drive and its last parent is deleted but the item itself is not, the item will be placed under its owner's root.",
+              "default": "false",
+              "location": "query"
+            }
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive"
+          ]
+        },
+        "export": {
+          "id": "drive.files.export",
+          "path": "files/{fileId}/export",
+          "httpMethod": "GET",
+          "description": "Exports a Google Workspace document to the requested MIME type and returns exported byte content. Note that the exported content is limited to 10MB.",
+          "parameters": {
+            "fileId": {
+              "type": "string",
+              "description": "The ID of the file.",
+              "required": true,
+              "location": "path"
+            },
+            "mimeType": {
+              "type": "string",
+              "description": "The MIME type of the format requested for this export.",
+              "required": true,
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "fileId",
+            "mimeType"
+          ],
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.file",
+            "https://www.googleapis.com/auth/drive.readonly"
+          ],
+          "supportsMediaDownload": true
+        },
+        "generateIds": {
+          "id": "drive.files.generateIds",
+          "path": "files/generateIds",
+          "httpMethod": "GET",
+          "description": "Generates a set of file IDs which can be provided in insert or copy requests.",
+          "parameters": {
+            "maxResults": {
+              "type": "integer",
+              "description": "Maximum number of IDs to return.",
+              "default": "10",
+              "format": "int32",
+              "minimum": "1",
+              "maximum": "1000",
+              "location": "query"
+            },
+            "space": {
+              "type": "string",
+              "description": "The space in which the IDs can be used to create new files. Supported values are 'drive' and 'appDataFolder'. (Default: 'drive')",
+              "default": "drive",
+              "location": "query"
+            },
+            "type": {
+              "type": "string",
+              "description": "The type of items which the IDs can be used for. Supported values are 'files' and 'shortcuts'. Note that 'shortcuts' are only supported in the drive 'space'. (Default: 'files')",
+              "default": "files",
+              "location": "query"
+            }
+          },
+          "response": {
+            "$ref": "GeneratedIds"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.appdata",
+            "https://www.googleapis.com/auth/drive.file"
+          ]
+        },
+        "get": {
+          "id": "drive.files.get",
+          "path": "files/{fileId}",
+          "httpMethod": "GET",
+          "description": "Gets a file's metadata or content by ID.",
+          "parameters": {
+            "acknowledgeAbuse": {
+              "type": "boolean",
+              "description": "Whether the user is acknowledging the risk of downloading known malware or other abusive files.",
+              "default": "false",
+              "location": "query"
+            },
+            "fileId": {
+              "type": "string",
+              "description": "The ID for the file in question.",
+              "required": true,
+              "location": "path"
+            },
+            "includePermissionsForView": {
+              "type": "string",
+              "description": "Specifies which additional view's permissions to include in the response. Only 'published' is supported.",
+              "location": "query"
+            },
+            "projection": {
+              "type": "string",
+              "description": "This parameter is deprecated and has no function.",
+              "enum": [
+                "BASIC",
+                "FULL"
+              ],
+              "enumDescriptions": [
+                "Deprecated",
+                "Deprecated"
+              ],
+              "location": "query"
+            },
+            "revisionId": {
+              "type": "string",
+              "description": "Specifies the Revision ID that should be downloaded. Ignored unless alt=media is specified.",
+              "location": "query"
+            },
+            "supportsAllDrives": {
+              "type": "boolean",
+              "description": "Whether the requesting application supports both My Drives and shared drives.",
+              "default": "false",
+              "location": "query"
+            },
+            "supportsTeamDrives": {
+              "type": "boolean",
+              "description": "Deprecated use supportsAllDrives instead.",
+              "default": "false",
+              "location": "query"
+            },
+            "updateViewedDate": {
+              "type": "boolean",
+              "description": "Deprecated: Use files.update with modifiedDateBehavior=noChange, updateViewedDate=true and an empty request body.",
+              "default": "false",
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "fileId"
+          ],
+          "response": {
+            "$ref": "File"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.appdata",
+            "https://www.googleapis.com/auth/drive.file",
+            "https://www.googleapis.com/auth/drive.metadata",
+            "https://www.googleapis.com/auth/drive.metadata.readonly",
+            "https://www.googleapis.com/auth/drive.photos.readonly",
+            "https://www.googleapis.com/auth/drive.readonly"
+          ],
+          "supportsMediaDownload": true,
+          "useMediaDownloadService": true,
+          "supportsSubscription": true
+        },
+        "insert": {
+          "id": "drive.files.insert",
+          "path": "files",
+          "httpMethod": "POST",
+          "description": "Insert a new file.",
+          "parameters": {
+            "convert": {
+              "type": "boolean",
+              "description": "Whether to convert this file to the corresponding Docs Editors format.",
+              "default": "false",
+              "location": "query"
+            },
+            "enforceSingleParent": {
+              "type": "boolean",
+              "description": "Deprecated. Creating files in multiple folders is no longer supported.",
+              "default": "false",
+              "location": "query"
+            },
+            "includePermissionsForView": {
+              "type": "string",
+              "description": "Specifies which additional view's permissions to include in the response. Only 'published' is supported.",
+              "location": "query"
+            },
+            "ocr": {
+              "type": "boolean",
+              "description": "Whether to attempt OCR on .jpg, .png, .gif, or .pdf uploads.",
+              "default": "false",
+              "location": "query"
+            },
+            "ocrLanguage": {
+              "type": "string",
+              "description": "If ocr is true, hints at the language to use. Valid values are BCP 47 codes.",
+              "location": "query"
+            },
+            "pinned": {
+              "type": "boolean",
+              "description": "Whether to pin the head revision of the uploaded file. A file can have a maximum of 200 pinned revisions.",
+              "default": "false",
+              "location": "query"
+            },
+            "supportsAllDrives": {
+              "type": "boolean",
+              "description": "Whether the requesting application supports both My Drives and shared drives.",
+              "default": "false",
+              "location": "query"
+            },
+            "supportsTeamDrives": {
+              "type": "boolean",
+              "description": "Deprecated use supportsAllDrives instead.",
+              "default": "false",
+              "location": "query"
+            },
+            "timedTextLanguage": {
+              "type": "string",
+              "description": "The language of the timed text.",
+              "location": "query"
+            },
+            "timedTextTrackName": {
+              "type": "string",
+              "description": "The timed text track name.",
+              "location": "query"
+            },
+            "useContentAsIndexableText": {
+              "type": "boolean",
+              "description": "Whether to use the content as indexable text.",
+              "default": "false",
+              "location": "query"
+            },
+            "visibility": {
+              "type": "string",
+              "description": "The visibility of the new file. This parameter is only relevant when convert=false.",
+              "default": "DEFAULT",
+              "enum": [
+                "DEFAULT",
+                "PRIVATE"
+              ],
+              "enumDescriptions": [
+                "The visibility of the new file is determined by the user's default visibility/sharing policies.",
+                "The new file will be visible to only the owner."
+              ],
+              "location": "query"
+            }
+          },
+          "request": {
+            "$ref": "File"
+          },
+          "response": {
+            "$ref": "File"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.appdata",
+            "https://www.googleapis.com/auth/drive.apps.readonly",
+            "https://www.googleapis.com/auth/drive.file"
+          ],
+          "supportsMediaUpload": true,
+          "mediaUpload": {
+            "accept": [
+              "*/*"
+            ],
+            "maxSize": "5120GB",
+            "protocols": {
+              "simple": {
+                "multipart": true,
+                "path": "/upload/drive/v2/files"
+              },
+              "resumable": {
+                "multipart": true,
+                "path": "/resumable/upload/drive/v2/files"
+              }
+            }
+          },
+          "supportsSubscription": true
+        },
+        "list": {
+          "id": "drive.files.list",
+          "path": "files",
+          "httpMethod": "GET",
+          "description": "Lists the user's files.",
+          "parameters": {
+            "corpora": {
+              "type": "string",
+              "description": "Groupings of files to which the query applies. Supported groupings are: 'user' (files created by, opened by, or shared directly with the user), 'drive' (files in the specified shared drive as indicated by the 'driveId'), 'domain' (files shared to the user's domain), and 'allDrives' (A combination of 'user' and 'drive' for all drives where the user is a member). When able, use 'user' or 'drive', instead of 'allDrives', for efficiency.",
+              "location": "query"
+            },
+            "corpus": {
+              "type": "string",
+              "description": "The body of items (files/documents) to which the query applies. Deprecated: use 'corpora' instead.",
+              "enum": [
+                "DEFAULT",
+                "DOMAIN"
+              ],
+              "enumDescriptions": [
+                "The items that the user has accessed.",
+                "Items shared to the user's domain."
+              ],
+              "location": "query"
+            },
+            "driveId": {
+              "type": "string",
+              "description": "ID of the shared drive to search.",
+              "location": "query"
+            },
+            "includeItemsFromAllDrives": {
+              "type": "boolean",
+              "description": "Whether both My Drive and shared drive items should be included in results.",
+              "default": "false",
+              "location": "query"
+            },
+            "includePermissionsForView": {
+              "type": "string",
+              "description": "Specifies which additional view's permissions to include in the response. Only 'published' is supported.",
+              "location": "query"
+            },
+            "includeTeamDriveItems": {
+              "type": "boolean",
+              "description": "Deprecated use includeItemsFromAllDrives instead.",
+              "default": "false",
+              "location": "query"
+            },
+            "maxResults": {
+              "type": "integer",
+              "description": "The maximum number of files to return per page. Partial or empty result pages are possible even before the end of the files list has been reached.",
+              "default": "100",
+              "format": "int32",
+              "minimum": "0",
+              "location": "query"
+            },
+            "orderBy": {
+              "type": "string",
+              "description": "A comma-separated list of sort keys. Valid keys are 'createdDate', 'folder', 'lastViewedByMeDate', 'modifiedByMeDate', 'modifiedDate', 'quotaBytesUsed', 'recency', 'sharedWithMeDate', 'starred', 'title', and 'title_natural'. Each key sorts ascending by default, but may be reversed with the 'desc' modifier. Example usage: ?orderBy=folder,modifiedDate desc,title. Please note that there is a current limitation for users with approximately one million files in which the requested sort order is ignored.",
+              "location": "query"
+            },
+            "pageToken": {
+              "type": "string",
+              "description": "Page token for files.",
+              "location": "query"
+            },
+            "projection": {
+              "type": "string",
+              "description": "This parameter is deprecated and has no function.",
+              "enum": [
+                "BASIC",
+                "FULL"
+              ],
+              "enumDescriptions": [
+                "Deprecated",
+                "Deprecated"
+              ],
+              "location": "query"
+            },
+            "q": {
+              "type": "string",
+              "description": "Query string for searching files.",
+              "location": "query"
+            },
+            "spaces": {
+              "type": "string",
+              "description": "A comma-separated list of spaces to query. Supported values are 'drive' and 'appDataFolder'.",
+              "location": "query"
+            },
+            "supportsAllDrives": {
+              "type": "boolean",
+              "description": "Whether the requesting application supports both My Drives and shared drives.",
+              "default": "false",
+              "location": "query"
+            },
+            "supportsTeamDrives": {
+              "type": "boolean",
+              "description": "Deprecated use supportsAllDrives instead.",
+              "default": "false",
+              "location": "query"
+            },
+            "teamDriveId": {
+              "type": "string",
+              "description": "Deprecated use driveId instead.",
+              "location": "query"
+            }
+          },
+          "response": {
+            "$ref": "FileList"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.appdata",
+            "https://www.googleapis.com/auth/drive.apps.readonly",
+            "https://www.googleapis.com/auth/drive.file",
+            "https://www.googleapis.com/auth/drive.metadata",
+            "https://www.googleapis.com/auth/drive.metadata.readonly",
+            "https://www.googleapis.com/auth/drive.photos.readonly",
+            "https://www.googleapis.com/auth/drive.readonly"
+          ]
+        },
+        "patch": {
+          "id": "drive.files.patch",
+          "path": "files/{fileId}",
+          "httpMethod": "PATCH",
+          "description": "Updates a file's metadata and/or content. When calling this method, only populate fields in the request that you want to modify. When updating fields, some fields might change automatically, such as modifiedDate. This method supports patch semantics.",
+          "parameters": {
+            "addParents": {
+              "type": "string",
+              "description": "Comma-separated list of parent IDs to add.",
+              "location": "query"
+            },
+            "convert": {
+              "type": "boolean",
+              "description": "This parameter is deprecated and has no function.",
+              "default": "false",
+              "location": "query"
+            },
+            "enforceSingleParent": {
+              "type": "boolean",
+              "description": "Deprecated. Adding files to multiple folders is no longer supported. Use shortcuts instead.",
+              "default": "false",
+              "location": "query"
+            },
+            "fileId": {
+              "type": "string",
+              "description": "The ID of the file to update.",
+              "required": true,
+              "location": "path"
+            },
+            "includePermissionsForView": {
+              "type": "string",
+              "description": "Specifies which additional view's permissions to include in the response. Only 'published' is supported.",
+              "location": "query"
+            },
+            "modifiedDateBehavior": {
+              "type": "string",
+              "description": "Determines the behavior in which modifiedDate is updated. This overrides setModifiedDate.",
+              "enum": [
+                "fromBody",
+                "fromBodyIfNeeded",
+                "fromBodyOrNow",
+                "noChange",
+                "now",
+                "nowIfNeeded"
+              ],
+              "enumDescriptions": [
+                "Set modifiedDate to the value provided in the body of the request. No change if no value was provided.",
+                "Set modifiedDate to the value provided in the body of the request depending on other contents of the update.",
+                "Set modifiedDate to the value provided in the body of the request, or to the current time if no value was provided.",
+                "Maintain the previous value of modifiedDate.",
+                "Set modifiedDate to the current time.",
+                "Set modifiedDate to the current time depending on contents of the update."
+              ],
+              "location": "query"
+            },
+            "newRevision": {
+              "type": "boolean",
+              "description": "Whether a blob upload should create a new revision. If false, the blob data in the current head revision is replaced. If true or not set, a new blob is created as head revision, and previous unpinned revisions are preserved for a short period of time. Pinned revisions are stored indefinitely, using additional storage quota, up to a maximum of 200 revisions. For details on how revisions are retained, see the Drive Help Center. Note that this field is ignored if there is no payload in the request.",
+              "default": "true",
+              "location": "query"
+            },
+            "ocr": {
+              "type": "boolean",
+              "description": "Whether to attempt OCR on .jpg, .png, .gif, or .pdf uploads.",
+              "default": "false",
+              "location": "query"
+            },
+            "ocrLanguage": {
+              "type": "string",
+              "description": "If ocr is true, hints at the language to use. Valid values are BCP 47 codes.",
+              "location": "query"
+            },
+            "pinned": {
+              "type": "boolean",
+              "description": "Whether to pin the new revision. A file can have a maximum of 200 pinned revisions. Note that this field is ignored if there is no payload in the request.",
+              "default": "false",
+              "location": "query"
+            },
+            "removeParents": {
+              "type": "string",
+              "description": "Comma-separated list of parent IDs to remove.",
+              "location": "query"
+            },
+            "setModifiedDate": {
+              "type": "boolean",
+              "description": "Whether to set the modified date using the value supplied in the request body. Setting this field to true is equivalent to modifiedDateBehavior=fromBodyOrNow, and false is equivalent to modifiedDateBehavior=now. To prevent any changes to the modified date set modifiedDateBehavior=noChange.",
+              "default": "false",
+              "location": "query"
+            },
+            "supportsAllDrives": {
+              "type": "boolean",
+              "description": "Whether the requesting application supports both My Drives and shared drives.",
+              "default": "false",
+              "location": "query"
+            },
+            "supportsTeamDrives": {
+              "type": "boolean",
+              "description": "Deprecated use supportsAllDrives instead.",
+              "default": "false",
+              "location": "query"
+            },
+            "timedTextLanguage": {
+              "type": "string",
+              "description": "The language of the timed text.",
+              "location": "query"
+            },
+            "timedTextTrackName": {
+              "type": "string",
+              "description": "The timed text track name.",
+              "location": "query"
+            },
+            "updateViewedDate": {
+              "type": "boolean",
+              "description": "Whether to update the view date after successfully updating the file.",
+              "default": "true",
+              "location": "query"
+            },
+            "useContentAsIndexableText": {
+              "type": "boolean",
+              "description": "Whether to use the content as indexable text.",
+              "default": "false",
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "fileId"
+          ],
+          "request": {
+            "$ref": "File"
+          },
+          "response": {
+            "$ref": "File"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.appdata",
+            "https://www.googleapis.com/auth/drive.apps.readonly",
+            "https://www.googleapis.com/auth/drive.file",
+            "https://www.googleapis.com/auth/drive.metadata",
+            "https://www.googleapis.com/auth/drive.scripts"
+          ]
+        },
+        "touch": {
+          "id": "drive.files.touch",
+          "path": "files/{fileId}/touch",
+          "httpMethod": "POST",
+          "description": "Set the file's updated time to the current server time.",
+          "parameters": {
+            "fileId": {
+              "type": "string",
+              "description": "The ID of the file to update.",
+              "required": true,
+              "location": "path"
+            },
+            "includePermissionsForView": {
+              "type": "string",
+              "description": "Specifies which additional view's permissions to include in the response. Only 'published' is supported.",
+              "location": "query"
+            },
+            "supportsAllDrives": {
+              "type": "boolean",
+              "description": "Whether the requesting application supports both My Drives and shared drives.",
+              "default": "false",
+              "location": "query"
+            },
+            "supportsTeamDrives": {
+              "type": "boolean",
+              "description": "Deprecated use supportsAllDrives instead.",
+              "default": "false",
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "fileId"
+          ],
+          "response": {
+            "$ref": "File"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.appdata",
+            "https://www.googleapis.com/auth/drive.apps.readonly",
+            "https://www.googleapis.com/auth/drive.file",
+            "https://www.googleapis.com/auth/drive.metadata"
+          ]
+        },
+        "trash": {
+          "id": "drive.files.trash",
+          "path": "files/{fileId}/trash",
+          "httpMethod": "POST",
+          "description": "Moves a file to the trash. The currently authenticated user must own the file or be at least a fileOrganizer on the parent for shared drive files. Only the owner may trash a file. The trashed item is excluded from all files.list responses returned for any user who does not own the file. However, all users with access to the file can see the trashed item metadata in an API response. All users with access can copy, download, export, and share the file.",
+          "parameters": {
+            "fileId": {
+              "type": "string",
+              "description": "The ID of the file to trash.",
+              "required": true,
+              "location": "path"
+            },
+            "includePermissionsForView": {
+              "type": "string",
+              "description": "Specifies which additional view's permissions to include in the response. Only 'published' is supported.",
+              "location": "query"
+            },
+            "supportsAllDrives": {
+              "type": "boolean",
+              "description": "Whether the requesting application supports both My Drives and shared drives.",
+              "default": "false",
+              "location": "query"
+            },
+            "supportsTeamDrives": {
+              "type": "boolean",
+              "description": "Deprecated use supportsAllDrives instead.",
+              "default": "false",
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "fileId"
+          ],
+          "response": {
+            "$ref": "File"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.appdata",
+            "https://www.googleapis.com/auth/drive.apps.readonly",
+            "https://www.googleapis.com/auth/drive.file"
+          ]
+        },
+        "untrash": {
+          "id": "drive.files.untrash",
+          "path": "files/{fileId}/untrash",
+          "httpMethod": "POST",
+          "description": "Restores a file from the trash. The currently authenticated user must own the file or be at least a fileOrganizer on the parent for shared drive files. Only the owner may untrash a file.",
+          "parameters": {
+            "fileId": {
+              "type": "string",
+              "description": "The ID of the file to untrash.",
+              "required": true,
+              "location": "path"
+            },
+            "includePermissionsForView": {
+              "type": "string",
+              "description": "Specifies which additional view's permissions to include in the response. Only 'published' is supported.",
+              "location": "query"
+            },
+            "supportsAllDrives": {
+              "type": "boolean",
+              "description": "Whether the requesting application supports both My Drives and shared drives.",
+              "default": "false",
+              "location": "query"
+            },
+            "supportsTeamDrives": {
+              "type": "boolean",
+              "description": "Deprecated use supportsAllDrives instead.",
+              "default": "false",
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "fileId"
+          ],
+          "response": {
+            "$ref": "File"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.appdata",
+            "https://www.googleapis.com/auth/drive.apps.readonly",
+            "https://www.googleapis.com/auth/drive.file"
+          ]
+        },
+        "update": {
+          "id": "drive.files.update",
+          "path": "files/{fileId}",
+          "httpMethod": "PUT",
+          "description": "Updates a file's metadata and/or content. When calling this method, only populate fields in the request that you want to modify. When updating fields, some fields might be changed automatically, such as modifiedDate. This method supports patch semantics.",
+          "parameters": {
+            "addParents": {
+              "type": "string",
+              "description": "Comma-separated list of parent IDs to add.",
+              "location": "query"
+            },
+            "convert": {
+              "type": "boolean",
+              "description": "This parameter is deprecated and has no function.",
+              "default": "false",
+              "location": "query"
+            },
+            "enforceSingleParent": {
+              "type": "boolean",
+              "description": "Deprecated. Adding files to multiple folders is no longer supported. Use shortcuts instead.",
+              "default": "false",
+              "location": "query"
+            },
+            "fileId": {
+              "type": "string",
+              "description": "The ID of the file to update.",
+              "required": true,
+              "location": "path"
+            },
+            "includePermissionsForView": {
+              "type": "string",
+              "description": "Specifies which additional view's permissions to include in the response. Only 'published' is supported.",
+              "location": "query"
+            },
+            "modifiedDateBehavior": {
+              "type": "string",
+              "description": "Determines the behavior in which modifiedDate is updated. This overrides setModifiedDate.",
+              "enum": [
+                "fromBody",
+                "fromBodyIfNeeded",
+                "fromBodyOrNow",
+                "noChange",
+                "now",
+                "nowIfNeeded"
+              ],
+              "enumDescriptions": [
+                "Set modifiedDate to the value provided in the body of the request. No change if no value was provided.",
+                "Set modifiedDate to the value provided in the body of the request depending on other contents of the update.",
+                "Set modifiedDate to the value provided in the body of the request, or to the current time if no value was provided.",
+                "Maintain the previous value of modifiedDate.",
+                "Set modifiedDate to the current time.",
+                "Set modifiedDate to the current time depending on contents of the update."
+              ],
+              "location": "query"
+            },
+            "newRevision": {
+              "type": "boolean",
+              "description": "Whether a blob upload should create a new revision. If false, the blob data in the current head revision is replaced. If true or not set, a new blob is created as head revision, and previous unpinned revisions are preserved for a short period of time. Pinned revisions are stored indefinitely, using additional storage quota, up to a maximum of 200 revisions. For details on how revisions are retained, see the Drive Help Center. Note that this field is ignored if there is no payload in the request.",
+              "default": "true",
+              "location": "query"
+            },
+            "ocr": {
+              "type": "boolean",
+              "description": "Whether to attempt OCR on .jpg, .png, .gif, or .pdf uploads.",
+              "default": "false",
+              "location": "query"
+            },
+            "ocrLanguage": {
+              "type": "string",
+              "description": "If ocr is true, hints at the language to use. Valid values are BCP 47 codes.",
+              "location": "query"
+            },
+            "pinned": {
+              "type": "boolean",
+              "description": "Whether to pin the new revision. A file can have a maximum of 200 pinned revisions. Note that this field is ignored if there is no payload in the request.",
+              "default": "false",
+              "location": "query"
+            },
+            "removeParents": {
+              "type": "string",
+              "description": "Comma-separated list of parent IDs to remove.",
+              "location": "query"
+            },
+            "setModifiedDate": {
+              "type": "boolean",
+              "description": "Whether to set the modified date using the value supplied in the request body. Setting this field to true is equivalent to modifiedDateBehavior=fromBodyOrNow, and false is equivalent to modifiedDateBehavior=now. To prevent any changes to the modified date set modifiedDateBehavior=noChange.",
+              "default": "false",
+              "location": "query"
+            },
+            "supportsAllDrives": {
+              "type": "boolean",
+              "description": "Whether the requesting application supports both My Drives and shared drives.",
+              "default": "false",
+              "location": "query"
+            },
+            "supportsTeamDrives": {
+              "type": "boolean",
+              "description": "Deprecated use supportsAllDrives instead.",
+              "default": "false",
+              "location": "query"
+            },
+            "timedTextLanguage": {
+              "type": "string",
+              "description": "The language of the timed text.",
+              "location": "query"
+            },
+            "timedTextTrackName": {
+              "type": "string",
+              "description": "The timed text track name.",
+              "location": "query"
+            },
+            "updateViewedDate": {
+              "type": "boolean",
+              "description": "Whether to update the view date after successfully updating the file.",
+              "default": "true",
+              "location": "query"
+            },
+            "useContentAsIndexableText": {
+              "type": "boolean",
+              "description": "Whether to use the content as indexable text.",
+              "default": "false",
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "fileId"
+          ],
+          "request": {
+            "$ref": "File"
+          },
+          "response": {
+            "$ref": "File"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.appdata",
+            "https://www.googleapis.com/auth/drive.apps.readonly",
+            "https://www.googleapis.com/auth/drive.file",
+            "https://www.googleapis.com/auth/drive.metadata",
+            "https://www.googleapis.com/auth/drive.scripts"
+          ],
+          "supportsMediaUpload": true,
+          "mediaUpload": {
+            "accept": [
+              "*/*"
+            ],
+            "maxSize": "5120GB",
+            "protocols": {
+              "simple": {
+                "multipart": true,
+                "path": "/upload/drive/v2/files/{fileId}"
+              },
+              "resumable": {
+                "multipart": true,
+                "path": "/resumable/upload/drive/v2/files/{fileId}"
+              }
+            }
+          }
+        },
+        "watch": {
+          "id": "drive.files.watch",
+          "path": "files/{fileId}/watch",
+          "httpMethod": "POST",
+          "description": "Subscribes to changes to a file. While you can establish a channel for changes to a file on a shared drive, a change to a shared drive file won't create a notification.",
+          "parameters": {
+            "acknowledgeAbuse": {
+              "type": "boolean",
+              "description": "Whether the user is acknowledging the risk of downloading known malware or other abusive files.",
+              "default": "false",
+              "location": "query"
+            },
+            "fileId": {
+              "type": "string",
+              "description": "The ID for the file in question.",
+              "required": true,
+              "location": "path"
+            },
+            "includePermissionsForView": {
+              "type": "string",
+              "description": "Specifies which additional view's permissions to include in the response. Only 'published' is supported.",
+              "location": "query"
+            },
+            "projection": {
+              "type": "string",
+              "description": "This parameter is deprecated and has no function.",
+              "enum": [
+                "BASIC",
+                "FULL"
+              ],
+              "enumDescriptions": [
+                "Deprecated",
+                "Deprecated"
+              ],
+              "location": "query"
+            },
+            "revisionId": {
+              "type": "string",
+              "description": "Specifies the Revision ID that should be downloaded. Ignored unless alt=media is specified.",
+              "location": "query"
+            },
+            "supportsAllDrives": {
+              "type": "boolean",
+              "description": "Whether the requesting application supports both My Drives and shared drives.",
+              "default": "false",
+              "location": "query"
+            },
+            "supportsTeamDrives": {
+              "type": "boolean",
+              "description": "Deprecated use supportsAllDrives instead.",
+              "default": "false",
+              "location": "query"
+            },
+            "updateViewedDate": {
+              "type": "boolean",
+              "description": "Deprecated: Use files.update with modifiedDateBehavior=noChange, updateViewedDate=true and an empty request body.",
+              "default": "false",
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "fileId"
+          ],
+          "request": {
+            "$ref": "Channel",
+            "parameterName": "resource"
+          },
+          "response": {
+            "$ref": "Channel"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.appdata",
+            "https://www.googleapis.com/auth/drive.file",
+            "https://www.googleapis.com/auth/drive.metadata",
+            "https://www.googleapis.com/auth/drive.metadata.readonly",
+            "https://www.googleapis.com/auth/drive.photos.readonly",
+            "https://www.googleapis.com/auth/drive.readonly"
+          ],
+          "supportsMediaDownload": true,
+          "useMediaDownloadService": true,
+          "supportsSubscription": true
+        }
+      }
+    },
+    "parents": {
+      "methods": {
+        "delete": {
+          "id": "drive.parents.delete",
+          "path": "files/{fileId}/parents/{parentId}",
+          "httpMethod": "DELETE",
+          "description": "Removes a parent from a file.",
+          "parameters": {
+            "enforceSingleParent": {
+              "type": "boolean",
+              "description": "Deprecated. If an item is not in a shared drive and its last parent is deleted but the item itself is not, the item will be placed under its owner's root.",
+              "default": "false",
+              "location": "query"
+            },
+            "fileId": {
+              "type": "string",
+              "description": "The ID of the file.",
+              "required": true,
+              "location": "path"
+            },
+            "parentId": {
+              "type": "string",
+              "description": "The ID of the parent.",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "parameterOrder": [
+            "fileId",
+            "parentId"
+          ],
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.file"
+          ]
+        },
+        "get": {
+          "id": "drive.parents.get",
+          "path": "files/{fileId}/parents/{parentId}",
+          "httpMethod": "GET",
+          "description": "Gets a specific parent reference.",
+          "parameters": {
+            "fileId": {
+              "type": "string",
+              "description": "The ID of the file.",
+              "required": true,
+              "location": "path"
+            },
+            "parentId": {
+              "type": "string",
+              "description": "The ID of the parent.",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "parameterOrder": [
+            "fileId",
+            "parentId"
+          ],
+          "response": {
+            "$ref": "ParentReference"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.appdata",
+            "https://www.googleapis.com/auth/drive.file",
+            "https://www.googleapis.com/auth/drive.metadata",
+            "https://www.googleapis.com/auth/drive.metadata.readonly",
+            "https://www.googleapis.com/auth/drive.photos.readonly",
+            "https://www.googleapis.com/auth/drive.readonly"
+          ]
+        },
+        "insert": {
+          "id": "drive.parents.insert",
+          "path": "files/{fileId}/parents",
+          "httpMethod": "POST",
+          "description": "Adds a parent folder for a file.",
+          "parameters": {
+            "enforceSingleParent": {
+              "type": "boolean",
+              "description": "Deprecated. Adding files to multiple folders is no longer supported. Use shortcuts instead.",
+              "default": "false",
+              "location": "query"
+            },
+            "fileId": {
+              "type": "string",
+              "description": "The ID of the file.",
+              "required": true,
+              "location": "path"
+            },
+            "supportsAllDrives": {
+              "type": "boolean",
+              "description": "Whether the requesting application supports both My Drives and shared drives.",
+              "default": "false",
+              "location": "query"
+            },
+            "supportsTeamDrives": {
+              "type": "boolean",
+              "description": "Deprecated use supportsAllDrives instead.",
+              "default": "false",
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "fileId"
+          ],
+          "request": {
+            "$ref": "ParentReference"
+          },
+          "response": {
+            "$ref": "ParentReference"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.appdata",
+            "https://www.googleapis.com/auth/drive.file"
+          ]
+        },
+        "list": {
+          "id": "drive.parents.list",
+          "path": "files/{fileId}/parents",
+          "httpMethod": "GET",
+          "description": "Lists a file's parents.",
+          "parameters": {
+            "fileId": {
+              "type": "string",
+              "description": "The ID of the file.",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "parameterOrder": [
+            "fileId"
+          ],
+          "response": {
+            "$ref": "ParentList"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.appdata",
+            "https://www.googleapis.com/auth/drive.file",
+            "https://www.googleapis.com/auth/drive.metadata",
+            "https://www.googleapis.com/auth/drive.metadata.readonly",
+            "https://www.googleapis.com/auth/drive.photos.readonly",
+            "https://www.googleapis.com/auth/drive.readonly"
+          ]
+        }
+      }
+    },
+    "permissions": {
+      "methods": {
+        "delete": {
+          "id": "drive.permissions.delete",
+          "path": "files/{fileId}/permissions/{permissionId}",
+          "httpMethod": "DELETE",
+          "description": "Deletes a permission from a file or shared drive.",
+          "parameters": {
+            "fileId": {
+              "type": "string",
+              "description": "The ID for the file or shared drive.",
+              "required": true,
+              "location": "path"
+            },
+            "permissionId": {
+              "type": "string",
+              "description": "The ID for the permission.",
+              "required": true,
+              "location": "path"
+            },
+            "supportsAllDrives": {
+              "type": "boolean",
+              "description": "Whether the requesting application supports both My Drives and shared drives.",
+              "default": "false",
+              "location": "query"
+            },
+            "supportsTeamDrives": {
+              "type": "boolean",
+              "description": "Deprecated use supportsAllDrives instead.",
+              "default": "false",
+              "location": "query"
+            },
+            "useDomainAdminAccess": {
+              "type": "boolean",
+              "description": "Issue the request as a domain administrator; if set to true, then the requester will be granted access if the file ID parameter refers to a shared drive and the requester is an administrator of the domain to which the shared drive belongs.",
+              "default": "false",
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "fileId",
+            "permissionId"
+          ],
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.file"
+          ]
+        },
+        "get": {
+          "id": "drive.permissions.get",
+          "path": "files/{fileId}/permissions/{permissionId}",
+          "httpMethod": "GET",
+          "description": "Gets a permission by ID.",
+          "parameters": {
+            "fileId": {
+              "type": "string",
+              "description": "The ID for the file or shared drive.",
+              "required": true,
+              "location": "path"
+            },
+            "permissionId": {
+              "type": "string",
+              "description": "The ID for the permission.",
+              "required": true,
+              "location": "path"
+            },
+            "supportsAllDrives": {
+              "type": "boolean",
+              "description": "Whether the requesting application supports both My Drives and shared drives.",
+              "default": "false",
+              "location": "query"
+            },
+            "supportsTeamDrives": {
+              "type": "boolean",
+              "description": "Deprecated use supportsAllDrives instead.",
+              "default": "false",
+              "location": "query"
+            },
+            "useDomainAdminAccess": {
+              "type": "boolean",
+              "description": "Issue the request as a domain administrator; if set to true, then the requester will be granted access if the file ID parameter refers to a shared drive and the requester is an administrator of the domain to which the shared drive belongs.",
+              "default": "false",
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "fileId",
+            "permissionId"
+          ],
+          "response": {
+            "$ref": "Permission"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.file",
+            "https://www.googleapis.com/auth/drive.metadata",
+            "https://www.googleapis.com/auth/drive.metadata.readonly",
+            "https://www.googleapis.com/auth/drive.photos.readonly",
+            "https://www.googleapis.com/auth/drive.readonly"
+          ]
+        },
+        "getIdForEmail": {
+          "id": "drive.permissions.getIdForEmail",
+          "path": "permissionIds/{email}",
+          "httpMethod": "GET",
+          "description": "Returns the permission ID for an email address.",
+          "parameters": {
+            "email": {
+              "type": "string",
+              "description": "The email address for which to return a permission ID",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "parameterOrder": [
+            "email"
+          ],
+          "response": {
+            "$ref": "PermissionId"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.appdata",
+            "https://www.googleapis.com/auth/drive.apps.readonly",
+            "https://www.googleapis.com/auth/drive.file",
+            "https://www.googleapis.com/auth/drive.metadata",
+            "https://www.googleapis.com/auth/drive.metadata.readonly",
+            "https://www.googleapis.com/auth/drive.photos.readonly",
+            "https://www.googleapis.com/auth/drive.readonly"
+          ]
+        },
+        "insert": {
+          "id": "drive.permissions.insert",
+          "path": "files/{fileId}/permissions",
+          "httpMethod": "POST",
+          "description": "Inserts a permission for a file or shared drive.",
+          "parameters": {
+            "emailMessage": {
+              "type": "string",
+              "description": "A plain text custom message to include in notification emails.",
+              "location": "query"
+            },
+            "enforceSingleParent": {
+              "type": "boolean",
+              "description": "Deprecated. See moveToNewOwnersRoot for details.",
+              "default": "false",
+              "location": "query"
+            },
+            "fileId": {
+              "type": "string",
+              "description": "The ID for the file or shared drive.",
+              "required": true,
+              "location": "path"
+            },
+            "moveToNewOwnersRoot": {
+              "type": "boolean",
+              "description": "This parameter will only take effect if the item is not in a shared drive and the request is attempting to transfer the ownership of the item. If set to true, the item will be moved to the new owner's My Drive root folder and all prior parents removed. If set to false, parents are not changed.",
+              "default": "false",
+              "location": "query"
+            },
+            "sendNotificationEmails": {
+              "type": "boolean",
+              "description": "Whether to send notification emails when sharing to users or groups. This parameter is ignored and an email is sent if the role is owner.",
+              "default": "true",
+              "location": "query"
+            },
+            "supportsAllDrives": {
+              "type": "boolean",
+              "description": "Whether the requesting application supports both My Drives and shared drives.",
+              "default": "false",
+              "location": "query"
+            },
+            "supportsTeamDrives": {
+              "type": "boolean",
+              "description": "Deprecated use supportsAllDrives instead.",
+              "default": "false",
+              "location": "query"
+            },
+            "useDomainAdminAccess": {
+              "type": "boolean",
+              "description": "Issue the request as a domain administrator; if set to true, then the requester will be granted access if the file ID parameter refers to a shared drive and the requester is an administrator of the domain to which the shared drive belongs.",
+              "default": "false",
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "fileId"
+          ],
+          "request": {
+            "$ref": "Permission"
+          },
+          "response": {
+            "$ref": "Permission"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.file"
+          ]
+        },
+        "list": {
+          "id": "drive.permissions.list",
+          "path": "files/{fileId}/permissions",
+          "httpMethod": "GET",
+          "description": "Lists a file's or shared drive's permissions.",
+          "parameters": {
+            "fileId": {
+              "type": "string",
+              "description": "The ID for the file or shared drive.",
+              "required": true,
+              "location": "path"
+            },
+            "includePermissionsForView": {
+              "type": "string",
+              "description": "Specifies which additional view's permissions to include in the response. Only 'published' is supported.",
+              "location": "query"
+            },
+            "maxResults": {
+              "type": "integer",
+              "description": "The maximum number of permissions to return per page. When not set for files in a shared drive, at most 100 results will be returned. When not set for files that are not in a shared drive, the entire list will be returned.",
+              "format": "int32",
+              "minimum": "1",
+              "maximum": "100",
+              "location": "query"
+            },
+            "pageToken": {
+              "type": "string",
+              "description": "The token for continuing a previous list request on the next page. This should be set to the value of 'nextPageToken' from the previous response.",
+              "location": "query"
+            },
+            "supportsAllDrives": {
+              "type": "boolean",
+              "description": "Whether the requesting application supports both My Drives and shared drives.",
+              "default": "false",
+              "location": "query"
+            },
+            "supportsTeamDrives": {
+              "type": "boolean",
+              "description": "Deprecated use supportsAllDrives instead.",
+              "default": "false",
+              "location": "query"
+            },
+            "useDomainAdminAccess": {
+              "type": "boolean",
+              "description": "Issue the request as a domain administrator; if set to true, then the requester will be granted access if the file ID parameter refers to a shared drive and the requester is an administrator of the domain to which the shared drive belongs.",
+              "default": "false",
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "fileId"
+          ],
+          "response": {
+            "$ref": "PermissionList"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.file",
+            "https://www.googleapis.com/auth/drive.metadata",
+            "https://www.googleapis.com/auth/drive.metadata.readonly",
+            "https://www.googleapis.com/auth/drive.photos.readonly",
+            "https://www.googleapis.com/auth/drive.readonly"
+          ]
+        },
+        "patch": {
+          "id": "drive.permissions.patch",
+          "path": "files/{fileId}/permissions/{permissionId}",
+          "httpMethod": "PATCH",
+          "description": "Updates a permission using patch semantics.",
+          "parameters": {
+            "fileId": {
+              "type": "string",
+              "description": "The ID for the file or shared drive.",
+              "required": true,
+              "location": "path"
+            },
+            "permissionId": {
+              "type": "string",
+              "description": "The ID for the permission.",
+              "required": true,
+              "location": "path"
+            },
+            "removeExpiration": {
+              "type": "boolean",
+              "description": "Whether to remove the expiration date.",
+              "default": "false",
+              "location": "query"
+            },
+            "supportsAllDrives": {
+              "type": "boolean",
+              "description": "Whether the requesting application supports both My Drives and shared drives.",
+              "default": "false",
+              "location": "query"
+            },
+            "supportsTeamDrives": {
+              "type": "boolean",
+              "description": "Deprecated use supportsAllDrives instead.",
+              "default": "false",
+              "location": "query"
+            },
+            "transferOwnership": {
+              "type": "boolean",
+              "description": "Whether changing a role to 'owner' downgrades the current owners to writers. Does nothing if the specified role is not 'owner'.",
+              "default": "false",
+              "location": "query"
+            },
+            "useDomainAdminAccess": {
+              "type": "boolean",
+              "description": "Issue the request as a domain administrator; if set to true, then the requester will be granted access if the file ID parameter refers to a shared drive and the requester is an administrator of the domain to which the shared drive belongs.",
+              "default": "false",
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "fileId",
+            "permissionId"
+          ],
+          "request": {
+            "$ref": "Permission"
+          },
+          "response": {
+            "$ref": "Permission"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.file"
+          ]
+        },
+        "update": {
+          "id": "drive.permissions.update",
+          "path": "files/{fileId}/permissions/{permissionId}",
+          "httpMethod": "PUT",
+          "description": "Updates a permission.",
+          "parameters": {
+            "fileId": {
+              "type": "string",
+              "description": "The ID for the file or shared drive.",
+              "required": true,
+              "location": "path"
+            },
+            "permissionId": {
+              "type": "string",
+              "description": "The ID for the permission.",
+              "required": true,
+              "location": "path"
+            },
+            "removeExpiration": {
+              "type": "boolean",
+              "description": "Whether to remove the expiration date.",
+              "default": "false",
+              "location": "query"
+            },
+            "supportsAllDrives": {
+              "type": "boolean",
+              "description": "Whether the requesting application supports both My Drives and shared drives.",
+              "default": "false",
+              "location": "query"
+            },
+            "supportsTeamDrives": {
+              "type": "boolean",
+              "description": "Deprecated use supportsAllDrives instead.",
+              "default": "false",
+              "location": "query"
+            },
+            "transferOwnership": {
+              "type": "boolean",
+              "description": "Whether to transfer ownership to the specified user and downgrade the current owner to a writer. This parameter is required as an acknowledgement of the side effect. File owners can only transfer ownership of files existing on My Drive. Files existing in a shared drive are owned by the organization that owns that shared drive. Ownership transfers are not supported for files and folders in shared drives. Organizers of a shared drive can move items from that shared drive into their My Drive which transfers the ownership to them.",
+              "default": "false",
+              "location": "query"
+            },
+            "useDomainAdminAccess": {
+              "type": "boolean",
+              "description": "Issue the request as a domain administrator; if set to true, then the requester will be granted access if the file ID parameter refers to a shared drive and the requester is an administrator of the domain to which the shared drive belongs.",
+              "default": "false",
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "fileId",
+            "permissionId"
+          ],
+          "request": {
+            "$ref": "Permission"
+          },
+          "response": {
+            "$ref": "Permission"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.file"
+          ]
+        }
+      }
+    },
+    "properties": {
+      "methods": {
+        "delete": {
+          "id": "drive.properties.delete",
+          "path": "files/{fileId}/properties/{propertyKey}",
+          "httpMethod": "DELETE",
+          "description": "Deletes a property.",
+          "parameters": {
+            "fileId": {
+              "type": "string",
+              "description": "The ID of the file.",
+              "required": true,
+              "location": "path"
+            },
+            "propertyKey": {
+              "type": "string",
+              "description": "The key of the property.",
+              "required": true,
+              "location": "path"
+            },
+            "visibility": {
+              "type": "string",
+              "description": "The visibility of the property.",
+              "default": "private",
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "fileId",
+            "propertyKey"
+          ],
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.appdata",
+            "https://www.googleapis.com/auth/drive.file",
+            "https://www.googleapis.com/auth/drive.metadata"
+          ]
+        },
+        "get": {
+          "id": "drive.properties.get",
+          "path": "files/{fileId}/properties/{propertyKey}",
+          "httpMethod": "GET",
+          "description": "Gets a property by its key.",
+          "parameters": {
+            "fileId": {
+              "type": "string",
+              "description": "The ID of the file.",
+              "required": true,
+              "location": "path"
+            },
+            "propertyKey": {
+              "type": "string",
+              "description": "The key of the property.",
+              "required": true,
+              "location": "path"
+            },
+            "visibility": {
+              "type": "string",
+              "description": "The visibility of the property.",
+              "default": "private",
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "fileId",
+            "propertyKey"
+          ],
+          "response": {
+            "$ref": "Property"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.appdata",
+            "https://www.googleapis.com/auth/drive.file",
+            "https://www.googleapis.com/auth/drive.metadata",
+            "https://www.googleapis.com/auth/drive.metadata.readonly",
+            "https://www.googleapis.com/auth/drive.photos.readonly",
+            "https://www.googleapis.com/auth/drive.readonly"
+          ]
+        },
+        "insert": {
+          "id": "drive.properties.insert",
+          "path": "files/{fileId}/properties",
+          "httpMethod": "POST",
+          "description": "Adds a property to a file, or updates it if it already exists.",
+          "parameters": {
+            "fileId": {
+              "type": "string",
+              "description": "The ID of the file.",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "parameterOrder": [
+            "fileId"
+          ],
+          "request": {
+            "$ref": "Property"
+          },
+          "response": {
+            "$ref": "Property"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.appdata",
+            "https://www.googleapis.com/auth/drive.file",
+            "https://www.googleapis.com/auth/drive.metadata"
+          ]
+        },
+        "list": {
+          "id": "drive.properties.list",
+          "path": "files/{fileId}/properties",
+          "httpMethod": "GET",
+          "description": "Lists a file's properties.",
+          "parameters": {
+            "fileId": {
+              "type": "string",
+              "description": "The ID of the file.",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "parameterOrder": [
+            "fileId"
+          ],
+          "response": {
+            "$ref": "PropertyList"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.appdata",
+            "https://www.googleapis.com/auth/drive.file",
+            "https://www.googleapis.com/auth/drive.metadata",
+            "https://www.googleapis.com/auth/drive.metadata.readonly",
+            "https://www.googleapis.com/auth/drive.photos.readonly",
+            "https://www.googleapis.com/auth/drive.readonly"
+          ]
+        },
+        "patch": {
+          "id": "drive.properties.patch",
+          "path": "files/{fileId}/properties/{propertyKey}",
+          "httpMethod": "PATCH",
+          "description": "Updates a property.",
+          "parameters": {
+            "fileId": {
+              "type": "string",
+              "description": "The ID of the file.",
+              "required": true,
+              "location": "path"
+            },
+            "propertyKey": {
+              "type": "string",
+              "description": "The key of the property.",
+              "required": true,
+              "location": "path"
+            },
+            "visibility": {
+              "type": "string",
+              "description": "The visibility of the property. Allowed values are PRIVATE and PUBLIC. (Default: PRIVATE)",
+              "default": "private",
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "fileId",
+            "propertyKey"
+          ],
+          "request": {
+            "$ref": "Property"
+          },
+          "response": {
+            "$ref": "Property"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.appdata",
+            "https://www.googleapis.com/auth/drive.file",
+            "https://www.googleapis.com/auth/drive.metadata"
+          ]
+        },
+        "update": {
+          "id": "drive.properties.update",
+          "path": "files/{fileId}/properties/{propertyKey}",
+          "httpMethod": "PUT",
+          "description": "Updates a property.",
+          "parameters": {
+            "fileId": {
+              "type": "string",
+              "description": "The ID of the file.",
+              "required": true,
+              "location": "path"
+            },
+            "propertyKey": {
+              "type": "string",
+              "description": "The key of the property.",
+              "required": true,
+              "location": "path"
+            },
+            "visibility": {
+              "type": "string",
+              "description": "The visibility of the property. Allowed values are PRIVATE and PUBLIC. (Default: PRIVATE)",
+              "default": "private",
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "fileId",
+            "propertyKey"
+          ],
+          "request": {
+            "$ref": "Property"
+          },
+          "response": {
+            "$ref": "Property"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.appdata",
+            "https://www.googleapis.com/auth/drive.file",
+            "https://www.googleapis.com/auth/drive.metadata"
+          ]
+        }
+      }
+    },
+    "replies": {
+      "methods": {
+        "delete": {
+          "id": "drive.replies.delete",
+          "path": "files/{fileId}/comments/{commentId}/replies/{replyId}",
+          "httpMethod": "DELETE",
+          "description": "Deletes a reply.",
+          "parameters": {
+            "commentId": {
+              "type": "string",
+              "description": "The ID of the comment.",
+              "required": true,
+              "location": "path"
+            },
+            "fileId": {
+              "type": "string",
+              "description": "The ID of the file.",
+              "required": true,
+              "location": "path"
+            },
+            "replyId": {
+              "type": "string",
+              "description": "The ID of the reply.",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "parameterOrder": [
+            "fileId",
+            "commentId",
+            "replyId"
+          ],
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.file"
+          ]
+        },
+        "get": {
+          "id": "drive.replies.get",
+          "path": "files/{fileId}/comments/{commentId}/replies/{replyId}",
+          "httpMethod": "GET",
+          "description": "Gets a reply.",
+          "parameters": {
+            "commentId": {
+              "type": "string",
+              "description": "The ID of the comment.",
+              "required": true,
+              "location": "path"
+            },
+            "fileId": {
+              "type": "string",
+              "description": "The ID of the file.",
+              "required": true,
+              "location": "path"
+            },
+            "includeDeleted": {
+              "type": "boolean",
+              "description": "If set, this will succeed when retrieving a deleted reply.",
+              "default": "false",
+              "location": "query"
+            },
+            "replyId": {
+              "type": "string",
+              "description": "The ID of the reply.",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "parameterOrder": [
+            "fileId",
+            "commentId",
+            "replyId"
+          ],
+          "response": {
+            "$ref": "CommentReply"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.file",
+            "https://www.googleapis.com/auth/drive.readonly"
+          ]
+        },
+        "insert": {
+          "id": "drive.replies.insert",
+          "path": "files/{fileId}/comments/{commentId}/replies",
+          "httpMethod": "POST",
+          "description": "Creates a new reply to the given comment.",
+          "parameters": {
+            "commentId": {
+              "type": "string",
+              "description": "The ID of the comment.",
+              "required": true,
+              "location": "path"
+            },
+            "fileId": {
+              "type": "string",
+              "description": "The ID of the file.",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "parameterOrder": [
+            "fileId",
+            "commentId"
+          ],
+          "request": {
+            "$ref": "CommentReply"
+          },
+          "response": {
+            "$ref": "CommentReply"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.file"
+          ]
+        },
+        "list": {
+          "id": "drive.replies.list",
+          "path": "files/{fileId}/comments/{commentId}/replies",
+          "httpMethod": "GET",
+          "description": "Lists all of the replies to a comment.",
+          "parameters": {
+            "commentId": {
+              "type": "string",
+              "description": "The ID of the comment.",
+              "required": true,
+              "location": "path"
+            },
+            "fileId": {
+              "type": "string",
+              "description": "The ID of the file.",
+              "required": true,
+              "location": "path"
+            },
+            "includeDeleted": {
+              "type": "boolean",
+              "description": "If set, all replies, including deleted replies (with content stripped) will be returned.",
+              "default": "false",
+              "location": "query"
+            },
+            "maxResults": {
+              "type": "integer",
+              "description": "The maximum number of replies to include in the response, used for paging.",
+              "default": "20",
+              "format": "int32",
+              "minimum": "0",
+              "maximum": "100",
+              "location": "query"
+            },
+            "pageToken": {
+              "type": "string",
+              "description": "The continuation token, used to page through large result sets. To get the next page of results, set this parameter to the value of \"nextPageToken\" from the previous response.",
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "fileId",
+            "commentId"
+          ],
+          "response": {
+            "$ref": "CommentReplyList"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.file",
+            "https://www.googleapis.com/auth/drive.readonly"
+          ]
+        },
+        "patch": {
+          "id": "drive.replies.patch",
+          "path": "files/{fileId}/comments/{commentId}/replies/{replyId}",
+          "httpMethod": "PATCH",
+          "description": "Updates an existing reply.",
+          "parameters": {
+            "commentId": {
+              "type": "string",
+              "description": "The ID of the comment.",
+              "required": true,
+              "location": "path"
+            },
+            "fileId": {
+              "type": "string",
+              "description": "The ID of the file.",
+              "required": true,
+              "location": "path"
+            },
+            "replyId": {
+              "type": "string",
+              "description": "The ID of the reply.",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "parameterOrder": [
+            "fileId",
+            "commentId",
+            "replyId"
+          ],
+          "request": {
+            "$ref": "CommentReply"
+          },
+          "response": {
+            "$ref": "CommentReply"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.file"
+          ]
+        },
+        "update": {
+          "id": "drive.replies.update",
+          "path": "files/{fileId}/comments/{commentId}/replies/{replyId}",
+          "httpMethod": "PUT",
+          "description": "Updates an existing reply.",
+          "parameters": {
+            "commentId": {
+              "type": "string",
+              "description": "The ID of the comment.",
+              "required": true,
+              "location": "path"
+            },
+            "fileId": {
+              "type": "string",
+              "description": "The ID of the file.",
+              "required": true,
+              "location": "path"
+            },
+            "replyId": {
+              "type": "string",
+              "description": "The ID of the reply.",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "parameterOrder": [
+            "fileId",
+            "commentId",
+            "replyId"
+          ],
+          "request": {
+            "$ref": "CommentReply"
+          },
+          "response": {
+            "$ref": "CommentReply"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.file"
+          ]
+        }
+      }
+    },
+    "revisions": {
+      "methods": {
+        "delete": {
+          "id": "drive.revisions.delete",
+          "path": "files/{fileId}/revisions/{revisionId}",
+          "httpMethod": "DELETE",
+          "description": "Permanently deletes a file version. You can only delete revisions for files with binary content, like images or videos. Revisions for other files, like Google Docs or Sheets, and the last remaining file version can't be deleted.",
+          "parameters": {
+            "fileId": {
+              "type": "string",
+              "description": "The ID of the file.",
+              "required": true,
+              "location": "path"
+            },
+            "revisionId": {
+              "type": "string",
+              "description": "The ID of the revision.",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "parameterOrder": [
+            "fileId",
+            "revisionId"
+          ],
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.appdata",
+            "https://www.googleapis.com/auth/drive.file"
+          ]
+        },
+        "get": {
+          "id": "drive.revisions.get",
+          "path": "files/{fileId}/revisions/{revisionId}",
+          "httpMethod": "GET",
+          "description": "Gets a specific revision.",
+          "parameters": {
+            "fileId": {
+              "type": "string",
+              "description": "The ID of the file.",
+              "required": true,
+              "location": "path"
+            },
+            "revisionId": {
+              "type": "string",
+              "description": "The ID of the revision.",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "parameterOrder": [
+            "fileId",
+            "revisionId"
+          ],
+          "response": {
+            "$ref": "Revision"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.appdata",
+            "https://www.googleapis.com/auth/drive.file",
+            "https://www.googleapis.com/auth/drive.metadata",
+            "https://www.googleapis.com/auth/drive.metadata.readonly",
+            "https://www.googleapis.com/auth/drive.photos.readonly",
+            "https://www.googleapis.com/auth/drive.readonly"
+          ]
+        },
+        "list": {
+          "id": "drive.revisions.list",
+          "path": "files/{fileId}/revisions",
+          "httpMethod": "GET",
+          "description": "Lists a file's revisions.",
+          "parameters": {
+            "fileId": {
+              "type": "string",
+              "description": "The ID of the file.",
+              "required": true,
+              "location": "path"
+            },
+            "maxResults": {
+              "type": "integer",
+              "description": "Maximum number of revisions to return.",
+              "default": "200",
+              "format": "int32",
+              "minimum": "1",
+              "maximum": "1000",
+              "location": "query"
+            },
+            "pageToken": {
+              "type": "string",
+              "description": "Page token for revisions. To get the next page of results, set this parameter to the value of \"nextPageToken\" from the previous response.",
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "fileId"
+          ],
+          "response": {
+            "$ref": "RevisionList"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.appdata",
+            "https://www.googleapis.com/auth/drive.file",
+            "https://www.googleapis.com/auth/drive.metadata",
+            "https://www.googleapis.com/auth/drive.metadata.readonly",
+            "https://www.googleapis.com/auth/drive.photos.readonly",
+            "https://www.googleapis.com/auth/drive.readonly"
+          ]
+        },
+        "patch": {
+          "id": "drive.revisions.patch",
+          "path": "files/{fileId}/revisions/{revisionId}",
+          "httpMethod": "PATCH",
+          "description": "Updates a revision.",
+          "parameters": {
+            "fileId": {
+              "type": "string",
+              "description": "The ID for the file.",
+              "required": true,
+              "location": "path"
+            },
+            "revisionId": {
+              "type": "string",
+              "description": "The ID for the revision.",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "parameterOrder": [
+            "fileId",
+            "revisionId"
+          ],
+          "request": {
+            "$ref": "Revision"
+          },
+          "response": {
+            "$ref": "Revision"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.appdata",
+            "https://www.googleapis.com/auth/drive.file"
+          ]
+        },
+        "update": {
+          "id": "drive.revisions.update",
+          "path": "files/{fileId}/revisions/{revisionId}",
+          "httpMethod": "PUT",
+          "description": "Updates a revision.",
+          "parameters": {
+            "fileId": {
+              "type": "string",
+              "description": "The ID for the file.",
+              "required": true,
+              "location": "path"
+            },
+            "revisionId": {
+              "type": "string",
+              "description": "The ID for the revision.",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "parameterOrder": [
+            "fileId",
+            "revisionId"
+          ],
+          "request": {
+            "$ref": "Revision"
+          },
+          "response": {
+            "$ref": "Revision"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.appdata",
+            "https://www.googleapis.com/auth/drive.file"
+          ]
+        }
+      }
+    },
+    "teamdrives": {
+      "methods": {
+        "delete": {
+          "id": "drive.teamdrives.delete",
+          "path": "teamdrives/{teamDriveId}",
+          "httpMethod": "DELETE",
+          "description": "Deprecated use drives.delete instead.",
+          "parameters": {
+            "teamDriveId": {
+              "type": "string",
+              "description": "The ID of the Team Drive",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "parameterOrder": [
+            "teamDriveId"
+          ],
+          "scopes": [
+            "https://www.googleapis.com/auth/drive"
+          ]
+        },
+        "get": {
+          "id": "drive.teamdrives.get",
+          "path": "teamdrives/{teamDriveId}",
+          "httpMethod": "GET",
+          "description": "Deprecated use drives.get instead.",
+          "parameters": {
+            "teamDriveId": {
+              "type": "string",
+              "description": "The ID of the Team Drive",
+              "required": true,
+              "location": "path"
+            },
+            "useDomainAdminAccess": {
+              "type": "boolean",
+              "description": "Issue the request as a domain administrator; if set to true, then the requester will be granted access if they are an administrator of the domain to which the Team Drive belongs.",
+              "default": "false",
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "teamDriveId"
+          ],
+          "response": {
+            "$ref": "TeamDrive"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.readonly"
+          ]
+        },
+        "insert": {
+          "id": "drive.teamdrives.insert",
+          "path": "teamdrives",
+          "httpMethod": "POST",
+          "description": "Deprecated use drives.insert instead.",
+          "parameters": {
+            "requestId": {
+              "type": "string",
+              "description": "An ID, such as a random UUID, which uniquely identifies this user's request for idempotent creation of a Team Drive. A repeated request by the same user and with the same request ID will avoid creating duplicates by attempting to create the same Team Drive. If the Team Drive already exists a 409 error will be returned.",
+              "required": true,
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "requestId"
+          ],
+          "request": {
+            "$ref": "TeamDrive"
+          },
+          "response": {
+            "$ref": "TeamDrive"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive"
+          ]
+        },
+        "list": {
+          "id": "drive.teamdrives.list",
+          "path": "teamdrives",
+          "httpMethod": "GET",
+          "description": "Deprecated use drives.list instead.",
+          "parameters": {
+            "maxResults": {
+              "type": "integer",
+              "description": "Maximum number of Team Drives to return.",
+              "default": "10",
+              "format": "int32",
+              "minimum": "1",
+              "maximum": "100",
+              "location": "query"
+            },
+            "pageToken": {
+              "type": "string",
+              "description": "Page token for Team Drives.",
+              "location": "query"
+            },
+            "q": {
+              "type": "string",
+              "description": "Query string for searching Team Drives.",
+              "location": "query"
+            },
+            "useDomainAdminAccess": {
+              "type": "boolean",
+              "description": "Issue the request as a domain administrator; if set to true, then all Team Drives of the domain in which the requester is an administrator are returned.",
+              "default": "false",
+              "location": "query"
+            }
+          },
+          "response": {
+            "$ref": "TeamDriveList"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/drive.readonly"
+          ]
+        },
+        "update": {
+          "id": "drive.teamdrives.update",
+          "path": "teamdrives/{teamDriveId}",
+          "httpMethod": "PUT",
+          "description": "Deprecated use drives.update instead.",
+          "parameters": {
+            "teamDriveId": {
+              "type": "string",
+              "description": "The ID of the Team Drive",
+              "required": true,
+              "location": "path"
+            },
+            "useDomainAdminAccess": {
+              "type": "boolean",
+              "description": "Issue the request as a domain administrator; if set to true, then the requester will be granted access if they are an administrator of the domain to which the Team Drive belongs.",
+              "default": "false",
+              "location": "query"
+            }
+          },
+          "parameterOrder": [
+            "teamDriveId"
+          ],
+          "request": {
+            "$ref": "TeamDrive"
+          },
+          "response": {
+            "$ref": "TeamDrive"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/drive"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/google-drive/shared/src/main/scala/gcp4s/drive/model/package.scala
+++ b/google-drive/shared/src/main/scala/gcp4s/drive/model/package.scala
@@ -1,0 +1,29 @@
+package gcp4s.drive
+
+import cats.syntax.all._
+import io.circe.Decoder.Result
+import io.circe._
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.FiniteDuration
+
+// TODO is this the right model for durations with GCP/drive? at least it will get things compiling for now
+package object model {
+  implicit final val finiteDurationDecoder: Decoder[FiniteDuration] =
+    new Decoder[FiniteDuration] {
+      def apply(c: HCursor): Result[FiniteDuration] =
+        for {
+          length <- c.downField("length").as[Long]
+          unitString <- c.downField("unit").as[String]
+          unit <- Either.catchOnly[IllegalArgumentException](TimeUnit.valueOf(unitString)).leftMap(DecodingFailure.fromThrowable(_, c.history))
+        } yield FiniteDuration(length, unit)
+    }
+
+  implicit final val finiteDurationEncoder: Encoder[FiniteDuration] = new Encoder[FiniteDuration] {
+    final def apply(a: FiniteDuration): Json =
+      Json.obj(
+        "length" -> Json.fromLong(a.length),
+        "unit"   -> Json.fromString(a.unit.name),
+      )
+  }
+}

--- a/project/CaseClass.scala
+++ b/project/CaseClass.scala
@@ -6,7 +6,11 @@ case class CaseClass(
     val name = Sanitize(this.name)
     s"""|final case class $name(
         |${parameters.map("  " + _).mkString(",\n")}
-        |) derives _root_.io.circe.Codec.AsObject
+        |)
+        |
+        |object $name {
+        |  implicit val ${name}Codec: _root_.io.circe.Codec[$name] = _root_.io.circe.generic.semiauto.deriveCodec
+        |}
         |""".stripMargin
   }
 }

--- a/project/DiscoveryPlugin.scala
+++ b/project/DiscoveryPlugin.scala
@@ -50,7 +50,7 @@ object DiscoveryPlugin extends AutoPlugin {
             f,
             s"""|package ${discoveryPackage.value}.model
                 |
-                |import _root_.gcp4s.json.given
+                |import _root_.io.circe.scodec._
                 |
                 |$caseClass
                 |""".stripMargin


### PR DESCRIPTION
As requested in https://github.com/armanbilge/gcp4s/issues/131#issuecomment-1150621614.

Originally, I copied the Discovery plugin stuff into a new project where I made these changes. In that project I was able to depend on a snapshot JAR built from [topic/2.13](https://github.com/armanbilge/gcp4s/tree/topic/2.13), using `CrossVersion.for2_13Use3`. I couldn't find a way to get sbt to do that for a submodule, so this doesn't really here work as-is, but you get the gist of it.

Also FWIW, I'm pretty sure the `FiniteDuration` codecs in `gcp4s.drive.model` are not really going to work either—I'd be surprised if they actually represent the duration values in the same way Google does. They're only there to get things building for now, but if we wanted to actually include Drive, I would go figure out how those values actually need to be encoded/decoded.