### PR TITLE
Fail Gcp4sLiveSuite early if no credentials

### DIFF
--- a/core/js/src/main/scala/gcp4s/platform.scala
+++ b/core/js/src/main/scala/gcp4s/platform.scala
@@ -22,17 +22,9 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.JSImport
 
 private[gcp4s] object platform:
-  def env = process.env
-  def home = Path(os.homedir())
   def windows = os.platform() == "wind32"
 
 @js.native
 @JSImport("os", JSImport.Default)
 private[gcp4s] object os extends js.Object:
-  def homedir(): String = js.native
   def platform(): String = js.native
-
-@js.native
-@JSImport("process", JSImport.Default)
-private[gcp4s] object process extends js.Object:
-  def env: js.Dictionary[String] = js.native

--- a/core/jvm/src/main/scala/gcp4s/platform.scala
+++ b/core/jvm/src/main/scala/gcp4s/platform.scala
@@ -21,6 +21,4 @@ import fs2.io.file.Path
 import scala.util.Properties
 
 private[gcp4s] object platform:
-  def env = sys.env
-  def home = Path(Properties.userHome)
   def windows = Properties.isWin

--- a/core/shared/src/main/scala/gcp4s/GoogleMiddleware.scala
+++ b/core/shared/src/main/scala/gcp4s/GoogleMiddleware.scala
@@ -19,6 +19,7 @@ package gcp4s
 import cats.effect.SyncIO
 import cats.effect.kernel.MonadCancelThrow
 import cats.effect.kernel.Temporal
+import cats.effect.std.Env
 import cats.syntax.all.*
 import fs2.io.file.Files
 import gcp4s.auth.ApplicationDefaultCredentials
@@ -38,7 +39,8 @@ import java.util.concurrent.ThreadLocalRandom
 import scala.concurrent.duration.*
 
 object GoogleMiddleware:
-  def apply[F[_]: Temporal: Files: Jwt](scopes: Seq[String])(client: Client[F]): F[Client[F]] =
+  def apply[F[_]: Temporal: Env: Files: Jwt](scopes: Seq[String])(
+      client: Client[F]): F[Client[F]] =
     val googleClient =
       Retry(GoogleRetryPolicy.Default.toRetryPolicy[F])(GoogleSystemParameters[F]()(client))
     for credentials <- ApplicationDefaultCredentials[F](googleClient, scopes)

--- a/core/shared/src/test/scala/gcp4s/Gcp4sLiveSuite.scala
+++ b/core/shared/src/test/scala/gcp4s/Gcp4sLiveSuite.scala
@@ -18,6 +18,7 @@ package gcp4s
 
 import cats.effect.IO
 import cats.effect.kernel.Deferred
+import cats.effect.kernel.Resource
 import cats.effect.std.Env
 import cats.effect.syntax.all.*
 import cats.effect.unsafe.implicits.*
@@ -33,8 +34,6 @@ import org.http4s.client.middleware.RequestLogger
 import org.http4s.client.middleware.ResponseLogger
 import org.http4s.client.middleware.Retry
 import org.http4s.ember.client.EmberClientBuilder
-import cats.effect.std.Env
-import cats.effect.kernel.Resource
 
 object Gcp4sLiveSuite:
   val scopes = List(

--- a/core/shared/src/test/scala/gcp4s/Gcp4sLiveSuite.scala
+++ b/core/shared/src/test/scala/gcp4s/Gcp4sLiveSuite.scala
@@ -18,6 +18,7 @@ package gcp4s
 
 import cats.effect.IO
 import cats.effect.kernel.Deferred
+import cats.effect.std.Env
 import cats.effect.syntax.all.*
 import cats.effect.unsafe.implicits.*
 import cats.syntax.all.*

--- a/core/shared/src/test/scala/gcp4s/Gcp4sLiveSuite.scala
+++ b/core/shared/src/test/scala/gcp4s/Gcp4sLiveSuite.scala
@@ -42,8 +42,7 @@ object Gcp4sLiveSuite:
   )
 
   private def credentials: Resource[IO, ServiceAccountCredentialsFile] =
-    Env
-      .make[IO]
+    Env[IO]
       .get("SERVICE_ACCOUNT_CREDENTIALS")
       .map(
         _.toRight(new Exception("Could not find 'SERVICE_ACCOUNT_CREDENTIALS' in ENV")).flatMap(


### PR DESCRIPTION
Previously if there was no `SERVICE_ACCOUNT_CREDENTIALS` environment variable the end-to-end tests would fail but only after munit timed out 30 seconds later.

This PR changes things to fail sooner and with a more direct error message:

```
gcp4s.bigquery.EndToEndSuite:                                                                                                                         
==> X gcp4s.bigquery.EndToEndSuite.projects contains project id  0.076s
  java.lang.Exception: Could not find 'SERVICE_ACCOUNT_CREDENTIALS' in ENV  
```